### PR TITLE
ci: Add release build job to PR checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,24 @@ jobs:
       - name: Test
         run: cargo test
 
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install libkrun stub
+        run: |
+          gcc -shared -o /tmp/libkrun.so ci/libkrun_stub.c
+          sudo cp /tmp/libkrun.so /usr/lib/
+          sudo ldconfig
+
+      - name: Build (release)
+        run: cargo build --release
+
   security:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Adds a `build` job that runs `cargo build --release` on every PR. Catches release-mode compilation failures before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration workflow with an additional build job for improved testing and release processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->