### PR TITLE
ci: Remove duplicate security job from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,19 +53,3 @@ jobs:
 
       - name: Build (release)
         run: cargo build --release
-
-  security:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: dtolnay/rust-toolchain@stable
-
-      - name: Install cargo-audit
-        run: cargo install cargo-audit cargo-deny
-
-      - name: Audit
-        run: cargo audit
-
-      - name: Deny
-        run: cargo deny check


### PR DESCRIPTION
The `security` job in ci.yml duplicates what security-audit.yml already does (cargo-audit + cargo-deny on every PR, plus weekly cron). Drop it.

After merge, update required checks to: `check`, `build`, `cargo-audit`, `cargo-deny`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted CI workflow configuration; no impact on user-facing functionality.
  * Continuous integration stages were reconfigured — routine checks, formatting, linting, and tests remain in place. This change affects only build/validation processes and does not alter product behavior or user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->