### PR TITLE
fix: Disable CodeRabbit PR description overwriting

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -1,6 +1,16 @@
 language: en
 early_access: true
+chat:
+  auto_reply: false
 reviews:
+  auto_review:
+    enabled: true
+  collapse_walkthrough: true
+  changed_files_summary: false
+  poem: false
+  high_level_summary: false
+  sequence_diagrams: false
+  abort_on_close: true
   profile: chill
   path_instructions:
     - path: "tests/**/*.rs"


### PR DESCRIPTION
CodeRabbit was replacing PR descriptions with its own summaries. Disabled summary, walkthrough, poems, and sequence diagrams. Keeps inline code review comments only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review automation configuration settings to refine review behavior and processing options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->