### PR TITLE
ci(#17): Use --locked for cargo commands in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,10 @@ jobs:
         run: cargo fmt -- --check
 
       - name: Lint
-        run: cargo clippy --all-targets -- -D warnings
+        run: cargo clippy --locked --all-targets -- -D warnings
 
       - name: Test
-        run: cargo test
+        run: cargo test --locked
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds `--locked` to `cargo clippy` and `cargo test` in the check job. CI will fail if Cargo.lock is out of date.

The build job (#14) should also get `--locked` once merged.

Fixes #17

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to ensure consistent dependency builds across development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->