### PR TITLE
deps: Bump getrandom from 0.2 to 0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -815,7 +815,7 @@ dependencies = [
  "clap",
  "env_logger",
  "flate2",
- "getrandom 0.2.17",
+ "getrandom 0.4.1",
  "httparse",
  "libc",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ toml = "1.0"
 minijinja = "2.15.1"
 thiserror = "2.0.18"
 shell-words = "1.1.1"
-getrandom = "0.2"
+getrandom = "0.4"
 
 [features]
 test-support = []

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -69,8 +69,7 @@ impl SecretBinding {
         }
 
         let mut buf = [0u8; 16];
-        getrandom::getrandom(&mut buf)
-            .map_err(|e| format!("failed to generate placeholder: {e}"))?;
+        getrandom::fill(&mut buf).map_err(|e| format!("failed to generate placeholder: {e}"))?;
         let suffix = buf.map(|b| format!("{b:02x}")).join("");
 
         Ok(Self {


### PR DESCRIPTION
getrandom 0.4 renames `getrandom::getrandom()` to `getrandom::fill()`. One-line change in secret.rs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated getrandom dependency to the latest version and adjusted internal random-generation implementation for compatibility; no user-visible behavioral changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->