### PR TITLE
ci: Add explicit permissions to workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -7,6 +7,9 @@ on:
     - cron: '0 6 * * 1'  # Weekly on Monday
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Least-privilege: `contents: read` only. Fixes CodeQL missing-workflow-permissions alerts (#11-16).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configurations to include content permissions settings.

**Note:** These are internal infrastructure changes with no impact on user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->