### PR TITLE
feat: make redan a daily driver (zero-config, sessions, image freshness)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ serde_json = "1.0.149"
 ureq = "3"
 httparse = "1.10.1"
 zeroize = { version = "1.8.2", features = ["derive"] }
-time = { version = "0.3.47", features = ["formatting"] }
+time = { version = "0.3.47", features = ["formatting", "parsing"] }
 toml = "1.0"
 minijinja = "2.15.1"
 thiserror = "2.0.18"

--- a/README.md
+++ b/README.md
@@ -448,7 +448,7 @@ redan stop my-agent           # stop by name or ID prefix
 ```bash
 redan logs                    # logs from most recent session
 redan logs -f                 # tail -f
-redan logs my-agent           # logs by session ID
+redan logs my-agent           # logs by name or session ID
 ```
 
 ## Audit log

--- a/README.md
+++ b/README.md
@@ -80,11 +80,11 @@ builds the `claude-code` image if needed, mounts the current directory,
 allows Anthropic's API hosts, and drops you into an interactive session.
 It prints what it chose so nothing is silent:
 
-```
+```text
   Using image: claude-code
   Injecting ANTHROPIC_API_KEY for api.anthropic.com
-  Mounting ~/.gitconfig (read-only)
-  Mounting ~/.ssh (read-only)
+  Mounting ~/.gitconfig
+  Mounting ~/.ssh
   Mounting current directory → /workspace
 ```
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ It prints what it chose so nothing is silent:
 
 Auto-detect kicks in when there's no `redan.toml` and no explicit CLI
 flags. Your `~/.gitconfig` and `~/.ssh` are mounted into the VM
-automatically so git works out of the box.
+automatically, and git remote hosts are added to the network allowlist
+so git works out of the box.
 
 ### With redan.toml
 
@@ -426,7 +427,7 @@ redan exec -d --name my-agent    # detach with a name
 ### Session management
 
 ```bash
-redan sessions                # list all sessions (shows name, status, age)
+redan sessions                # list all sessions
 redan sessions show <id>      # session details
 redan sessions remove         # remove all exited sessions
 redan sessions remove <id>    # remove a specific session

--- a/README.md
+++ b/README.md
@@ -65,7 +65,36 @@ redan doctor
 
 ## Setup with Claude Code
 
-The fastest way to get started:
+### Zero-config (recommended)
+
+Set your API key and run:
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+cd ~/my-project
+redan exec
+```
+
+That's it. Redan auto-detects Claude Code: picks up your API key,
+builds the `claude-code` image if needed, mounts the current directory,
+allows Anthropic's API hosts, and drops you into an interactive session.
+It prints what it chose so nothing is silent:
+
+```
+  Using image: claude-code
+  Injecting ANTHROPIC_API_KEY for api.anthropic.com
+  Mounting ~/.gitconfig (read-only)
+  Mounting ~/.ssh (read-only)
+  Mounting current directory → /workspace
+```
+
+Auto-detect kicks in when there's no `redan.toml` and no explicit CLI
+flags. Your `~/.gitconfig` and `~/.ssh` are mounted into the VM
+automatically so git works out of the box.
+
+### With redan.toml
+
+For repeatable setups, use `redan init`:
 
 ```bash
 redan init --claude
@@ -77,7 +106,7 @@ redan exec
 and project-appropriate tooling (Python/uv, Rust, Go, etc.) plus a
 `redan.toml` with Anthropic API hosts pre-configured.
 
-Or use the provided Dockerfile directly:
+### Manual
 
 ```bash
 redan image import claude-code --dockerfile dockerfiles/claude-code.dockerfile
@@ -127,7 +156,26 @@ merges them into the network allowlist automatically.
 
 ## Quick start
 
-### Run an agent
+### Run an agent (zero-config)
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+redan exec
+```
+
+The agent sees `$ANTHROPIC_API_KEY` as a placeholder token. The proxy
+injects the real key only in HTTPS requests to `api.anthropic.com`.
+Responses are scrubbed of the real value before the agent sees them.
+
+### Run in the background
+
+```bash
+redan exec -d --name my-agent
+redan logs my-agent -f           # tail the logs
+redan stop my-agent              # stop when done
+```
+
+### Run with explicit config
 
 ```bash
 redan exec --image claude-code \
@@ -136,24 +184,9 @@ redan exec --image claude-code \
   -- claude --print "review this project"
 ```
 
-The agent sees `$ANTHROPIC_API_KEY` as a placeholder token. The proxy
-injects the real key only in HTTPS requests to `api.anthropic.com`.
-Responses are scrubbed of the real value before the agent sees them.
-
 **Note:** `--secret` literal values are visible in process listings (`ps`).
 For production use, prefer `env://`, `vault://`, `--secret-file`, or
 shell expansion: `--secret "KEY=$(cat /path/to/secret):host"`.
-
-### Interactive mode
-
-```bash
-redan exec --image claude-code -i \
-  --secret "ANTHROPIC_API_KEY=sk-ant-...:api.anthropic.com" \
-  --mount ./my-project
-```
-
-Drops you into a shell inside the VM. Same secret injection, same
-network isolation.
 
 ### Check prerequisites
 
@@ -163,7 +196,8 @@ redan doctor --image myimage         # check a specific image exists
 redan doctor --secret "KEY=val:host" # validate secret syntax + providers
 ```
 
-Checks for /dev/kvm, libkrun, libkrunfw, and available images.
+Checks for /dev/kvm, libkrun, libkrunfw, available images, and
+whether `ANTHROPIC_API_KEY` is set (for zero-config Claude Code).
 
 ## How it works
 
@@ -291,6 +325,7 @@ redan image import myimage --from ubuntu:24.04
 redan image import myimage --dockerfile path/to/Dockerfile
 redan image import myimage --devcontainer .devcontainer
 redan image list
+redan image update myimage
 redan image remove myimage
 ```
 
@@ -301,6 +336,21 @@ supported).
 
 Images are rootfs directories stored at `~/.local/share/redan/images/`
 and base tarballs are cached at `~/.cache/redan/`.
+
+### Image freshness
+
+Redan tracks when images were built and from what source. `redan image
+list` shows the age of each image, `redan doctor` warns about images
+older than 30 days, and `redan exec` prints a non-blocking warning
+before launching.
+
+```bash
+redan image update claude-code   # rebuild from the original Dockerfile
+```
+
+`redan image update` remembers how the image was built (Dockerfile,
+Docker image, devcontainer, or `create` args) and rebuilds from
+the same source.
 
 ## Network policy
 
@@ -363,14 +413,41 @@ Copy the output into your `redan.toml` and subsequent runs enforce it.
 Each `redan exec` creates a session with a unique ID. Session metadata,
 logs, and audit events are stored at `~/.local/state/redan/sessions/`.
 
+### Detached sessions
+
+Run agents in the background:
+
 ```bash
-redan sessions                # list all sessions
+redan exec -d                    # detach, auto-generated ID
+redan exec -d --name my-agent    # detach with a name
+```
+
+### Session management
+
+```bash
+redan sessions                # list all sessions (shows name, status, age)
 redan sessions show <id>      # session details
 redan sessions remove         # remove all exited sessions
 redan sessions remove <id>    # remove a specific session
+```
+
+### Attach and stop
+
+```bash
+redan attach                  # attach to most recent running session
+redan attach my-agent         # attach by name or ID prefix
+redan stop                    # stop most recent running session
+redan stop my-agent           # stop by name or ID prefix
+```
+
+`redan stop` sends SIGTERM, waits 3 seconds, then SIGKILL.
+
+### Logs
+
+```bash
 redan logs                    # logs from most recent session
 redan logs -f                 # tail -f
-redan logs <id>               # logs from a specific session
+redan logs my-agent           # logs by session ID
 ```
 
 ## Audit log

--- a/README.md
+++ b/README.md
@@ -185,8 +185,9 @@ redan exec --image claude-code \
 ```
 
 **Note:** `--secret` literal values are visible in process listings (`ps`).
-For production use, prefer `env://`, `vault://`, `--secret-file`, or
-shell expansion: `--secret "KEY=$(cat /path/to/secret):host"`.
+For production use, prefer `env://`, `vault://`, or `--secret-file`,
+which keep secrets out of process listings by having redan read them
+internally.
 
 ### Check prerequisites
 

--- a/src/auto_detect.rs
+++ b/src/auto_detect.rs
@@ -147,7 +147,9 @@ fn home_dir() -> Option<String> {
     std::env::var("HOME").ok()
 }
 
-/// Fields from CLI that indicate the user wants manual control (not auto-detect).
+/// Config-level fields from CLI that indicate the user wants manual control
+/// (not auto-detect). Mode flags like --detach and --name are excluded;
+/// they modify how the session runs, not what it runs.
 pub struct ExecFlags<'a> {
     pub image: &'a Option<String>,
     pub rootfs: &'a Option<String>,
@@ -156,10 +158,11 @@ pub struct ExecFlags<'a> {
     pub secret_file: &'a Option<String>,
     pub mounts: &'a [String],
     pub discover: bool,
-    pub detach: bool,
 }
 
-/// Check if any explicit exec flags were provided on the CLI.
+/// Whether the user passed any config-level flags (image, secrets, mounts, etc.).
+/// Mode flags like --detach and --name don't count; they modify how the
+/// session runs, not what it runs.
 pub const fn has_explicit_flags(f: &ExecFlags<'_>) -> bool {
     f.image.is_some()
         || f.rootfs.is_some()
@@ -168,7 +171,6 @@ pub const fn has_explicit_flags(f: &ExecFlags<'_>) -> bool {
         || f.secret_file.is_some()
         || !f.mounts.is_empty()
         || f.discover
-        || f.detach
 }
 
 #[cfg(test)]
@@ -238,7 +240,6 @@ mod tests {
             secret_file: &None,
             mounts: &[],
             discover: false,
-            detach: false,
         }
     }
 
@@ -269,14 +270,6 @@ mod tests {
     fn explicit_flags_detects_discover() {
         assert!(has_explicit_flags(&ExecFlags {
             discover: true,
-            ..empty_flags()
-        }));
-    }
-
-    #[test]
-    fn explicit_flags_detects_detach() {
-        assert!(has_explicit_flags(&ExecFlags {
-            detach: true,
             ..empty_flags()
         }));
     }

--- a/src/auto_detect.rs
+++ b/src/auto_detect.rs
@@ -147,26 +147,28 @@ fn home_dir() -> Option<String> {
     std::env::var("HOME").ok()
 }
 
+/// Fields from CLI that indicate the user wants manual control (not auto-detect).
+pub struct ExecFlags<'a> {
+    pub image: &'a Option<String>,
+    pub rootfs: &'a Option<String>,
+    pub command: &'a [String],
+    pub secrets: &'a [String],
+    pub secret_file: &'a Option<String>,
+    pub mounts: &'a [String],
+    pub discover: bool,
+    pub detach: bool,
+}
+
 /// Check if any explicit exec flags were provided on the CLI.
-///
-/// Returns true if the user passed flags that indicate they want
-/// manual control (not auto-detect).
-pub const fn has_explicit_flags(
-    image: &Option<String>,
-    rootfs: &Option<String>,
-    command: &[String],
-    secrets: &[String],
-    secret_file: &Option<String>,
-    mounts: &[String],
-    discover: bool,
-) -> bool {
-    image.is_some()
-        || rootfs.is_some()
-        || !command.is_empty()
-        || !secrets.is_empty()
-        || secret_file.is_some()
-        || !mounts.is_empty()
-        || discover
+pub const fn has_explicit_flags(f: &ExecFlags<'_>) -> bool {
+    f.image.is_some()
+        || f.rootfs.is_some()
+        || !f.command.is_empty()
+        || !f.secrets.is_empty()
+        || f.secret_file.is_some()
+        || !f.mounts.is_empty()
+        || f.discover
+        || f.detach
 }
 
 #[cfg(test)]
@@ -183,12 +185,10 @@ mod tests {
         assert_eq!(auto.config.interactive, Some(true));
         assert!(!auto.needs_image_build);
 
-        // Secret should be env:// reference, not the literal key
         let secret = auto.config.secrets.get("ANTHROPIC_API_KEY").unwrap();
         assert_eq!(secret.value, "env://ANTHROPIC_API_KEY");
         assert_eq!(secret.hosts, vec!["api.anthropic.com"]);
 
-        // Network should have Claude hosts
         assert!(
             auto.config
                 .network
@@ -202,10 +202,7 @@ mod tests {
                 .contains(&"statsig.anthropic.com".to_string())
         );
 
-        // Mount should have workspace
         assert!(auto.config.mount.contains_key("workspace"));
-
-        // Messages should describe what was chosen
         assert!(auto.messages.iter().any(|m| m.contains("claude-code")));
         assert!(
             auto.messages
@@ -224,57 +221,63 @@ mod tests {
 
     #[test]
     fn detect_returns_none_without_api_key() {
-        let result = detect_with_env(None, true, Some("/home/testuser"));
-        assert!(result.is_none());
+        assert!(detect_with_env(None, true, Some("/home/testuser")).is_none());
     }
 
     #[test]
     fn detect_returns_none_with_empty_api_key() {
-        let result = detect_with_env(Some(String::new()), true, Some("/home/testuser"));
-        assert!(result.is_none());
+        assert!(detect_with_env(Some(String::new()), true, Some("/home/testuser")).is_none());
+    }
+
+    fn empty_flags() -> ExecFlags<'static> {
+        ExecFlags {
+            image: &None,
+            rootfs: &None,
+            command: &[],
+            secrets: &[],
+            secret_file: &None,
+            mounts: &[],
+            discover: false,
+            detach: false,
+        }
     }
 
     #[test]
-    fn has_explicit_flags_detects_image() {
-        assert!(has_explicit_flags(
-            &Some("myimage".into()),
-            &None,
-            &[],
-            &[],
-            &None,
-            &[],
-            false
-        ));
+    fn explicit_flags_none_when_empty() {
+        assert!(!has_explicit_flags(&empty_flags()));
     }
 
     #[test]
-    fn has_explicit_flags_detects_command() {
-        assert!(has_explicit_flags(
-            &None,
-            &None,
-            &["echo".into(), "hello".into()],
-            &[],
-            &None,
-            &[],
-            false
-        ));
+    fn explicit_flags_detects_image() {
+        let img = Some("myimage".into());
+        assert!(has_explicit_flags(&ExecFlags {
+            image: &img,
+            ..empty_flags()
+        }));
     }
 
     #[test]
-    fn has_explicit_flags_none_when_empty() {
-        assert!(!has_explicit_flags(
-            &None,
-            &None,
-            &[],
-            &[],
-            &None,
-            &[],
-            false
-        ));
+    fn explicit_flags_detects_command() {
+        let cmd = vec!["echo".into(), "hello".into()];
+        assert!(has_explicit_flags(&ExecFlags {
+            command: &cmd,
+            ..empty_flags()
+        }));
     }
 
     #[test]
-    fn has_explicit_flags_detects_discover() {
-        assert!(has_explicit_flags(&None, &None, &[], &[], &None, &[], true));
+    fn explicit_flags_detects_discover() {
+        assert!(has_explicit_flags(&ExecFlags {
+            discover: true,
+            ..empty_flags()
+        }));
+    }
+
+    #[test]
+    fn explicit_flags_detects_detach() {
+        assert!(has_explicit_flags(&ExecFlags {
+            detach: true,
+            ..empty_flags()
+        }));
     }
 }

--- a/src/auto_detect.rs
+++ b/src/auto_detect.rs
@@ -73,10 +73,17 @@ fn detect_with_env(
         ..Config::default()
     };
 
-    // Network: Claude's required hosts
-    config.network = NetworkConfig {
-        allow: CLAUDE_HOSTS.iter().map(|&h| h.to_string()).collect(),
-    };
+    // Network: Claude's required hosts + git remote hosts from the working directory
+    let mut allow: Vec<String> = CLAUDE_HOSTS.iter().map(|&h| h.to_string()).collect();
+    let git_hosts = git_remote_hosts();
+    if !git_hosts.is_empty() {
+        messages.push(format!(
+            "Allowing git remote hosts: {}",
+            git_hosts.join(", ")
+        ));
+        allow.extend(git_hosts);
+    }
+    config.network = NetworkConfig { allow };
 
     // Secret: ANTHROPIC_API_KEY via env://
     config.secrets.insert(
@@ -101,7 +108,11 @@ fn detect_with_env(
         .env
         .insert("CLAUDE_CONFIG_DIR".into(), "/workspace/.claude".into());
 
-    // Git/SSH identity mounts
+    // Git/SSH identity mounts.
+    // NOTE: virtio-fs via libkrun does not currently support read-only mounts,
+    // so these are writable by the guest. The network policy is the primary
+    // security boundary. Users who need stronger isolation should use a
+    // redan.toml with explicit --mount entries.
     if let Some(home) = home {
         let gitconfig = Path::new(home).join(".gitconfig");
         if gitconfig.exists() {
@@ -145,6 +156,52 @@ fn image_exists(name: &str) -> bool {
 
 fn home_dir() -> Option<String> {
     std::env::var("HOME").ok()
+}
+
+/// Extract hostnames from git remote URLs in the current directory.
+/// Parses `git remote -v` output; returns empty vec if git isn't available
+/// or we're not in a repo.
+fn git_remote_hosts() -> Vec<String> {
+    let output = std::process::Command::new("git")
+        .args(["remote", "-v"])
+        .stderr(std::process::Stdio::null())
+        .output();
+    let output = match output {
+        Ok(o) if o.status.success() => o,
+        _ => return Vec::new(),
+    };
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut hosts: Vec<String> = stdout
+        .lines()
+        .filter_map(|line| {
+            // Lines look like: origin	git@github.com:user/repo.git (fetch)
+            // or: origin	https://github.com/user/repo.git (fetch)
+            let url = line.split_whitespace().nth(1)?;
+            host_from_remote_url(url)
+        })
+        .collect();
+    hosts.sort();
+    hosts.dedup();
+    hosts
+}
+
+/// Extract hostname from a git remote URL (SSH or HTTPS).
+fn host_from_remote_url(url: &str) -> Option<String> {
+    // HTTPS: https://github.com/user/repo.git
+    if let Some(rest) = url
+        .strip_prefix("https://")
+        .or_else(|| url.strip_prefix("http://"))
+    {
+        return rest.split('/').next().map(|h| {
+            // Strip port if present: github.com:8443 -> github.com
+            h.split(':').next().unwrap_or(h).to_string()
+        });
+    }
+    // SSH: git@github.com:user/repo.git
+    if let Some((_user, host_and_path)) = url.split_once('@') {
+        return host_and_path.split(':').next().map(String::from);
+    }
+    None
 }
 
 /// Config-level fields from CLI that indicate the user wants manual control
@@ -272,5 +329,42 @@ mod tests {
             discover: true,
             ..empty_flags()
         }));
+    }
+
+    #[test]
+    fn host_from_https_url() {
+        assert_eq!(
+            host_from_remote_url("https://github.com/user/repo.git"),
+            Some("github.com".into())
+        );
+    }
+
+    #[test]
+    fn host_from_ssh_url() {
+        assert_eq!(
+            host_from_remote_url("git@github.com:user/repo.git"),
+            Some("github.com".into())
+        );
+    }
+
+    #[test]
+    fn host_from_https_with_port() {
+        assert_eq!(
+            host_from_remote_url("https://gitlab.example.com:8443/group/repo.git"),
+            Some("gitlab.example.com".into())
+        );
+    }
+
+    #[test]
+    fn host_from_ssh_custom_host() {
+        assert_eq!(
+            host_from_remote_url("git@gitlab.internal.corp:team/project.git"),
+            Some("gitlab.internal.corp".into())
+        );
+    }
+
+    #[test]
+    fn host_from_nonsense_returns_none() {
+        assert_eq!(host_from_remote_url("not-a-url"), None);
     }
 }

--- a/src/auto_detect.rs
+++ b/src/auto_detect.rs
@@ -1,0 +1,280 @@
+//! Zero-config auto-detection for `redan exec`.
+//!
+//! When no `redan.toml` exists and no CLI flags are given, redan tries to
+//! detect a usable configuration automatically. Currently detects Claude Code
+//! setups: if the `claude-code` image exists and `ANTHROPIC_API_KEY` is set,
+//! redan runs Claude Code with smart defaults.
+
+use std::path::Path;
+
+use crate::config::{Config, MountConfig, NetworkConfig, SecretConfig};
+use crate::image;
+
+/// Hosts required for Claude Code to function.
+const CLAUDE_HOSTS: &[&str] = &[
+    "api.anthropic.com",
+    "statsig.anthropic.com",
+    "sentry.io",
+    "platform.claude.com",
+    "raw.githubusercontent.com",
+];
+
+/// Result of auto-detection: a Config plus messages about what was detected.
+pub struct AutoDetected {
+    pub config: Config,
+    /// Human-readable lines describing what was detected and chosen.
+    pub messages: Vec<String>,
+    /// Whether the claude-code image needs to be built first.
+    pub needs_image_build: bool,
+}
+
+/// Attempt to build a Config from environment detection.
+///
+/// Returns `None` if auto-detection can't produce a usable config
+/// (e.g., no known image, no API key).
+pub fn detect() -> Option<AutoDetected> {
+    let home = home_dir();
+    detect_with_env(
+        std::env::var("ANTHROPIC_API_KEY").ok(),
+        image_exists("claude-code"),
+        home.as_deref(),
+    )
+}
+
+/// Testable inner function with injected environment.
+fn detect_with_env(
+    anthropic_key: Option<String>,
+    claude_image_exists: bool,
+    home: Option<&str>,
+) -> Option<AutoDetected> {
+    // For now, we only auto-detect Claude Code setups.
+    // Future: detect other agent types (Codex, etc.)
+    let api_key = anthropic_key?;
+    if api_key.is_empty() {
+        return None;
+    }
+
+    let mut messages = Vec::new();
+    let needs_image_build = !claude_image_exists;
+
+    if claude_image_exists {
+        messages.push("Using image: claude-code".into());
+    } else {
+        messages.push("Image claude-code not found, will build from bundled Dockerfile".into());
+    }
+
+    messages.push("Injecting ANTHROPIC_API_KEY for api.anthropic.com".into());
+
+    let mut config = Config {
+        image: Some("claude-code".into()),
+        command: Some("claude --dangerously-skip-permissions".into()),
+        interactive: Some(true),
+        timeout: Some(3600),
+        ..Config::default()
+    };
+
+    // Network: Claude's required hosts
+    config.network = NetworkConfig {
+        allow: CLAUDE_HOSTS.iter().map(|&h| h.to_string()).collect(),
+    };
+
+    // Secret: ANTHROPIC_API_KEY via env://
+    config.secrets.insert(
+        "ANTHROPIC_API_KEY".into(),
+        SecretConfig {
+            value: "env://ANTHROPIC_API_KEY".to_string(),
+            hosts: vec!["api.anthropic.com".into()],
+        },
+    );
+
+    // Mount: current directory → /workspace
+    config.mount.insert(
+        "workspace".into(),
+        MountConfig {
+            source: ".".into(),
+            target: Some("/workspace".into()),
+        },
+    );
+
+    // Claude Code config dir in workspace
+    config
+        .env
+        .insert("CLAUDE_CONFIG_DIR".into(), "/workspace/.claude".into());
+
+    // Git/SSH identity mounts
+    if let Some(home) = home {
+        let gitconfig = Path::new(home).join(".gitconfig");
+        if gitconfig.exists() {
+            config.mount.insert(
+                "gitconfig".into(),
+                MountConfig {
+                    source: gitconfig.to_string_lossy().into_owned(),
+                    target: Some("/home/dev/.gitconfig".into()),
+                },
+            );
+            messages.push("Mounting ~/.gitconfig (read-only)".into());
+        }
+
+        let ssh_dir = Path::new(home).join(".ssh");
+        if ssh_dir.is_dir() {
+            config.mount.insert(
+                "ssh".into(),
+                MountConfig {
+                    source: ssh_dir.to_string_lossy().into_owned(),
+                    target: Some("/home/dev/.ssh".into()),
+                },
+            );
+            messages.push("Mounting ~/.ssh (read-only)".into());
+        }
+    }
+
+    // Summarize mount
+    messages.push("Mounting current directory → /workspace".into());
+
+    Some(AutoDetected {
+        config,
+        messages,
+        needs_image_build,
+    })
+}
+
+/// Check if a named image exists.
+fn image_exists(name: &str) -> bool {
+    image::image_path(name).map(|p| p.exists()).unwrap_or(false)
+}
+
+fn home_dir() -> Option<String> {
+    std::env::var("HOME").ok()
+}
+
+/// Check if any explicit exec flags were provided on the CLI.
+///
+/// Returns true if the user passed flags that indicate they want
+/// manual control (not auto-detect).
+pub const fn has_explicit_flags(
+    image: &Option<String>,
+    rootfs: &Option<String>,
+    command: &[String],
+    secrets: &[String],
+    secret_file: &Option<String>,
+    mounts: &[String],
+    discover: bool,
+) -> bool {
+    image.is_some()
+        || rootfs.is_some()
+        || !command.is_empty()
+        || !secrets.is_empty()
+        || secret_file.is_some()
+        || !mounts.is_empty()
+        || discover
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_claude_code_with_key_and_image() {
+        let result = detect_with_env(Some("sk-ant-test123".into()), true, Some("/home/testuser"));
+        let auto = result.expect("should detect");
+        assert_eq!(auto.config.image.as_deref(), Some("claude-code"));
+        assert!(auto.config.command.as_deref().unwrap().contains("claude"));
+        assert_eq!(auto.config.interactive, Some(true));
+        assert!(!auto.needs_image_build);
+
+        // Secret should be env:// reference, not the literal key
+        let secret = auto.config.secrets.get("ANTHROPIC_API_KEY").unwrap();
+        assert_eq!(secret.value, "env://ANTHROPIC_API_KEY");
+        assert_eq!(secret.hosts, vec!["api.anthropic.com"]);
+
+        // Network should have Claude hosts
+        assert!(
+            auto.config
+                .network
+                .allow
+                .contains(&"api.anthropic.com".to_string())
+        );
+        assert!(
+            auto.config
+                .network
+                .allow
+                .contains(&"statsig.anthropic.com".to_string())
+        );
+
+        // Mount should have workspace
+        assert!(auto.config.mount.contains_key("workspace"));
+
+        // Messages should describe what was chosen
+        assert!(auto.messages.iter().any(|m| m.contains("claude-code")));
+        assert!(
+            auto.messages
+                .iter()
+                .any(|m| m.contains("ANTHROPIC_API_KEY"))
+        );
+    }
+
+    #[test]
+    fn detect_needs_image_build_when_missing() {
+        let result = detect_with_env(Some("sk-ant-test123".into()), false, Some("/home/testuser"));
+        let auto = result.expect("should detect");
+        assert!(auto.needs_image_build);
+        assert!(auto.messages.iter().any(|m| m.contains("will build")));
+    }
+
+    #[test]
+    fn detect_returns_none_without_api_key() {
+        let result = detect_with_env(None, true, Some("/home/testuser"));
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn detect_returns_none_with_empty_api_key() {
+        let result = detect_with_env(Some(String::new()), true, Some("/home/testuser"));
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn has_explicit_flags_detects_image() {
+        assert!(has_explicit_flags(
+            &Some("myimage".into()),
+            &None,
+            &[],
+            &[],
+            &None,
+            &[],
+            false
+        ));
+    }
+
+    #[test]
+    fn has_explicit_flags_detects_command() {
+        assert!(has_explicit_flags(
+            &None,
+            &None,
+            &["echo".into(), "hello".into()],
+            &[],
+            &None,
+            &[],
+            false
+        ));
+    }
+
+    #[test]
+    fn has_explicit_flags_none_when_empty() {
+        assert!(!has_explicit_flags(
+            &None,
+            &None,
+            &[],
+            &[],
+            &None,
+            &[],
+            false
+        ));
+    }
+
+    #[test]
+    fn has_explicit_flags_detects_discover() {
+        assert!(has_explicit_flags(&None, &None, &[], &[], &None, &[], true));
+    }
+}

--- a/src/auto_detect.rs
+++ b/src/auto_detect.rs
@@ -185,19 +185,26 @@ fn git_remote_hosts() -> Vec<String> {
     hosts
 }
 
-/// Extract hostname from a git remote URL (SSH or HTTPS).
+/// Extract hostname from a git remote URL.
+/// Handles HTTPS, HTTP, ssh://, and SCP-style (git@host:path) formats.
 fn host_from_remote_url(url: &str) -> Option<String> {
-    // HTTPS: https://github.com/user/repo.git
+    // ssh://[user@]host[:port]/path
+    if let Some(rest) = url.strip_prefix("ssh://") {
+        let authority = rest.rsplit_once('@').map_or(rest, |(_, a)| a);
+        let host = authority.split('/').next()?;
+        return Some(host.split(':').next().unwrap_or(host).to_string());
+    }
+    // https://host[:port]/path or http://
     if let Some(rest) = url
         .strip_prefix("https://")
         .or_else(|| url.strip_prefix("http://"))
     {
-        return rest.split('/').next().map(|h| {
-            // Strip port if present: github.com:8443 -> github.com
-            h.split(':').next().unwrap_or(h).to_string()
-        });
+        return rest
+            .split('/')
+            .next()
+            .map(|h| h.split(':').next().unwrap_or(h).to_string());
     }
-    // SSH: git@github.com:user/repo.git
+    // SCP-style: git@github.com:user/repo.git
     if let Some((_user, host_and_path)) = url.split_once('@') {
         return host_and_path.split(':').next().map(String::from);
     }
@@ -360,6 +367,22 @@ mod tests {
         assert_eq!(
             host_from_remote_url("git@gitlab.internal.corp:team/project.git"),
             Some("gitlab.internal.corp".into())
+        );
+    }
+
+    #[test]
+    fn host_from_ssh_scheme() {
+        assert_eq!(
+            host_from_remote_url("ssh://git@github.com/org/repo.git"),
+            Some("github.com".into())
+        );
+    }
+
+    #[test]
+    fn host_from_ssh_scheme_with_port() {
+        assert_eq!(
+            host_from_remote_url("ssh://git@gitlab.example.com:2222/group/repo.git"),
+            Some("gitlab.example.com".into())
         );
     }
 

--- a/src/auto_detect.rs
+++ b/src/auto_detect.rs
@@ -50,7 +50,7 @@ fn detect_with_env(
     // For now, we only auto-detect Claude Code setups.
     // Future: detect other agent types (Codex, etc.)
     let api_key = anthropic_key?;
-    if api_key.is_empty() {
+    if api_key.trim().is_empty() {
         return None;
     }
 
@@ -112,7 +112,7 @@ fn detect_with_env(
                     target: Some("/home/dev/.gitconfig".into()),
                 },
             );
-            messages.push("Mounting ~/.gitconfig (read-only)".into());
+            messages.push("Mounting ~/.gitconfig".into());
         }
 
         let ssh_dir = Path::new(home).join(".ssh");
@@ -124,7 +124,7 @@ fn detect_with_env(
                     target: Some("/home/dev/.ssh".into()),
                 },
             );
-            messages.push("Mounting ~/.ssh (read-only)".into());
+            messages.push("Mounting ~/.ssh".into());
         }
     }
 

--- a/src/cmd/doctor.rs
+++ b/src/cmd/doctor.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 use super::exec::parse_secret;
 use redan::image;
+use redan::image_meta::ImageMeta;
 
 pub(crate) fn run(secret_specs: &[String], check_image: Option<&str>) {
     let mut ok = true;
@@ -63,6 +64,18 @@ pub(crate) fn run(secret_specs: &[String], check_image: Option<&str>) {
         );
     } else {
         println!("[ok]   images: {}", images.join(", "));
+    }
+
+    // Check image freshness
+    for name in &images {
+        if let Ok(path) = image::image_path(name)
+            && let Some(meta) = ImageMeta::load(&path)
+            && let Some(days) = meta.age_days()
+            && days > 30
+        {
+            println!("[warn] image {name}: {days} days old");
+            println!("       run: redan image update {name}");
+        }
     }
 
     if let Some(name) = check_image {

--- a/src/cmd/doctor.rs
+++ b/src/cmd/doctor.rs
@@ -80,6 +80,18 @@ pub(crate) fn run(secret_specs: &[String], check_image: Option<&str>) {
         }
     }
 
+    // ANTHROPIC_API_KEY check (when claude-code image exists)
+    if images.contains(&"claude-code".to_string()) {
+        if std::env::var("ANTHROPIC_API_KEY").is_ok_and(|v| !v.is_empty()) {
+            println!("[ok]   ANTHROPIC_API_KEY: set");
+        } else {
+            println!("[warn] ANTHROPIC_API_KEY: not set");
+            println!(
+                "       needed for zero-config Claude Code: export ANTHROPIC_API_KEY=sk-ant-..."
+            );
+        }
+    }
+
     // Validate secrets (never print values)
     for spec in secret_specs {
         let env_label = spec.split_once('=').map_or("(invalid)", |(name, _)| name);

--- a/src/cmd/exec.rs
+++ b/src/cmd/exec.rs
@@ -22,16 +22,30 @@ pub(crate) struct ExecConfig<'a> {
     pub guest_env: &'a BTreeMap<String, String>,
     pub discover: bool,
     pub session_name: Option<&'a str>,
+    /// Pre-existing session ID (for daemon mode). If None, creates a new session.
+    pub session_id: Option<&'a str>,
 }
 
 pub(crate) fn run(cfg: &ExecConfig<'_>) {
-    // Create session
-    let session_id = session::new_id();
-    let mut meta = session::SessionMeta::new(&session_id, cfg.image_name, Some(cfg.command));
-    meta.name = cfg.session_name.map(Into::into);
-    if let Err(e) = meta.save() {
-        log::warn!("cannot save session metadata: {e}");
-    }
+    // Create or reuse session
+    let session_id = cfg.session_id.map_or_else(session::new_id, Into::into);
+    let mut meta = if cfg.session_id.is_some() {
+        // Daemon mode: reload existing metadata (written by exec_detached)
+        let meta_path = session::session_dir(&session_id).join("meta.json");
+        std::fs::read_to_string(&meta_path)
+            .ok()
+            .and_then(|json| serde_json::from_str(&json).ok())
+            .unwrap_or_else(|| {
+                session::SessionMeta::new(&session_id, cfg.image_name, Some(cfg.command))
+            })
+    } else {
+        let mut m = session::SessionMeta::new(&session_id, cfg.image_name, Some(cfg.command));
+        m.name = cfg.session_name.map(Into::into);
+        if let Err(e) = m.save() {
+            log::warn!("cannot save session metadata: {e}");
+        }
+        m
+    };
     log::info!("session {session_id} started");
 
     // In interactive mode, redirect logs to a file so they don't

--- a/src/cmd/exec.rs
+++ b/src/cmd/exec.rs
@@ -21,12 +21,14 @@ pub(crate) struct ExecConfig<'a> {
     pub image_name: Option<&'a str>,
     pub guest_env: &'a BTreeMap<String, String>,
     pub discover: bool,
+    pub session_name: Option<&'a str>,
 }
 
 pub(crate) fn run(cfg: &ExecConfig<'_>) {
     // Create session
     let session_id = session::new_id();
     let mut meta = session::SessionMeta::new(&session_id, cfg.image_name, Some(cfg.command));
+    meta.name = cfg.session_name.map(Into::into);
     if let Err(e) = meta.save() {
         log::warn!("cannot save session metadata: {e}");
     }
@@ -195,7 +197,7 @@ pub(crate) fn run(cfg: &ExecConfig<'_>) {
 
     // In interactive mode, set the host terminal to raw mode
     let _raw_guard = if cfg.interactive {
-        Some(RawTerminalGuard::enter())
+        Some(redan::terminal::RawTerminalGuard::enter())
     } else {
         None
     };
@@ -352,36 +354,6 @@ fn write_guest_policy(rootfs: &Path, allowed_hosts: Option<&Vec<String>>) {
         return;
     }
     let _ = std::fs::write(dir.join("policy"), templates::guest_policy(allowed_hosts));
-}
-
-/// RAII guard: raw terminal mode on creation, restore on drop.
-struct RawTerminalGuard {
-    original: libc::termios,
-}
-
-impl RawTerminalGuard {
-    fn enter() -> Self {
-        unsafe {
-            let mut original: libc::termios = std::mem::zeroed();
-            libc::tcgetattr(libc::STDIN_FILENO, std::ptr::from_mut(&mut original));
-            let mut raw = original;
-            libc::cfmakeraw(std::ptr::from_mut(&mut raw));
-            libc::tcsetattr(libc::STDIN_FILENO, libc::TCSANOW, std::ptr::from_ref(&raw));
-            Self { original }
-        }
-    }
-}
-
-impl Drop for RawTerminalGuard {
-    fn drop(&mut self) {
-        unsafe {
-            libc::tcsetattr(
-                libc::STDIN_FILENO,
-                libc::TCSANOW,
-                std::ptr::from_ref(&self.original),
-            );
-        }
-    }
 }
 
 #[cfg(test)]

--- a/src/cmd/exec.rs
+++ b/src/cmd/exec.rs
@@ -29,15 +29,21 @@ pub(crate) struct ExecConfig<'a> {
 pub(crate) fn run(cfg: &ExecConfig<'_>) {
     // Create or reuse session
     let session_id = cfg.session_id.map_or_else(session::new_id, Into::into);
+    if cfg.session_id.is_some() && !session::valid_session_id(&session_id) {
+        eprintln!("invalid session ID: {session_id}");
+        std::process::exit(1);
+    }
     let mut meta = if cfg.session_id.is_some() {
         // Daemon mode: reload existing metadata (written by exec_detached)
         let meta_path = session::session_dir(&session_id).join("meta.json");
-        std::fs::read_to_string(&meta_path)
-            .ok()
-            .and_then(|json| serde_json::from_str(&json).ok())
-            .unwrap_or_else(|| {
-                session::SessionMeta::new(&session_id, cfg.image_name, Some(cfg.command))
-            })
+        let json = std::fs::read_to_string(&meta_path).unwrap_or_else(|e| {
+            eprintln!("cannot read session metadata {}: {e}", meta_path.display());
+            std::process::exit(1);
+        });
+        serde_json::from_str(&json).unwrap_or_else(|e| {
+            eprintln!("invalid session metadata {}: {e}", meta_path.display());
+            std::process::exit(1);
+        })
     } else {
         let mut m = session::SessionMeta::new(&session_id, cfg.image_name, Some(cfg.command));
         m.name = cfg.session_name.map(Into::into);
@@ -211,7 +217,13 @@ pub(crate) fn run(cfg: &ExecConfig<'_>) {
 
     // In interactive mode, set the host terminal to raw mode
     let _raw_guard = if cfg.interactive {
-        Some(redan::terminal::RawTerminalGuard::enter())
+        match redan::terminal::RawTerminalGuard::enter() {
+            Ok(guard) => Some(guard),
+            Err(e) => {
+                eprintln!("warning: cannot enter raw terminal mode: {e}");
+                None
+            }
+        }
     } else {
         None
     };

--- a/src/image.rs
+++ b/src/image.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 use std::{fs, io};
 
 use crate::ca::MitmCa;
+use crate::image_meta::{ImageMeta, ImageSource};
 use crate::{proxy, vm};
 
 const ALPINE_VERSION: &str = "3.21.3";
@@ -161,6 +162,13 @@ pub fn create(name: &str, packages: &[String], run_commands: &[String]) -> io::R
     // From here, clean up dest on any error.
     match build_image(&dest, packages, run_commands) {
         Ok(()) => {
+            let meta = ImageMeta::new(ImageSource::Create {
+                packages: packages.to_vec(),
+                run_commands: run_commands.to_vec(),
+            });
+            if let Err(e) = meta.save(&dest) {
+                log::warn!("cannot save image metadata: {e}");
+            }
             eprintln!("image '{name}' created at {}", dest.display());
             Ok(dest)
         }
@@ -323,6 +331,13 @@ fn import_docker_inner(name: &str, docker_image: &str, pull: bool) -> io::Result
         ));
     }
 
+    let meta = ImageMeta::new(ImageSource::Docker {
+        image: docker_image.into(),
+    });
+    if let Err(e) = meta.save(&dest) {
+        log::warn!("cannot save image metadata: {e}");
+    }
+
     eprintln!("image '{name}' imported from {docker_image}");
     eprintln!("  {}", dest.display());
     Ok(dest)
@@ -364,6 +379,16 @@ pub fn import_dockerfile(name: &str, dockerfile_path: &str) -> io::Result<PathBu
         .args(["rmi", &tag])
         .status();
 
+    // Save build metadata after successful import
+    if let Ok(ref dest) = result {
+        let meta = ImageMeta::new(ImageSource::Dockerfile {
+            path: dockerfile_path.into(),
+        });
+        if let Err(e) = meta.save(dest) {
+            log::warn!("cannot save image metadata: {e}");
+        }
+    }
+
     result
 }
 
@@ -377,6 +402,17 @@ pub fn import_dockerfile(name: &str, dockerfile_path: &str) -> io::Result<PathBu
 /// or `.devcontainer.json` (per the spec).
 #[allow(clippy::too_many_lines)] // Devcontainer has 3 code paths (dockerfile, image, compose)
 pub fn import_devcontainer(name: &str, config_path: &str) -> io::Result<PathBuf> {
+    let result = import_devcontainer_inner(name, config_path)?;
+    let meta = ImageMeta::new(ImageSource::Devcontainer {
+        path: config_path.into(),
+    });
+    if let Err(e) = meta.save(&result) {
+        log::warn!("cannot save image metadata: {e}");
+    }
+    Ok(result)
+}
+
+fn import_devcontainer_inner(name: &str, config_path: &str) -> io::Result<PathBuf> {
     let config_file = Path::new(config_path);
     if !config_file.exists() {
         return Err(io::Error::new(

--- a/src/image_meta.rs
+++ b/src/image_meta.rs
@@ -1,0 +1,131 @@
+//! Image metadata: build date, source, and freshness tracking.
+//!
+//! Stored as `.redan-image.json` inside the image directory.
+
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+const META_FILE: &str = ".redan-image.json";
+
+/// How the image was built, for rebuilding.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum ImageSource {
+    /// Built from a Dockerfile.
+    Dockerfile { path: String },
+    /// Imported from a Docker image.
+    Docker { image: String },
+    /// Built from a devcontainer config.
+    Devcontainer { path: String },
+    /// Created via `redan image create`.
+    Create {
+        packages: Vec<String>,
+        run_commands: Vec<String>,
+    },
+    /// Unknown source (pre-metadata images).
+    Unknown,
+}
+
+/// Metadata stored alongside an image.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ImageMeta {
+    /// When the image was built (RFC 3339).
+    pub built_at: String,
+    /// How it was built.
+    pub source: ImageSource,
+}
+
+impl ImageMeta {
+    pub fn new(source: ImageSource) -> Self {
+        let built_at = time::OffsetDateTime::now_utc()
+            .format(&time::format_description::well_known::Rfc3339)
+            .unwrap_or_default();
+        Self { built_at, source }
+    }
+
+    /// Write metadata to the image directory.
+    pub fn save(&self, image_dir: &Path) -> Result<(), String> {
+        let path = image_dir.join(META_FILE);
+        let json = serde_json::to_string_pretty(self)
+            .map_err(|e| format!("cannot serialize image meta: {e}"))?;
+        std::fs::write(&path, json).map_err(|e| format!("cannot write {}: {e}", path.display()))
+    }
+
+    /// Read metadata from an image directory. Returns None if not found.
+    pub fn load(image_dir: &Path) -> Option<Self> {
+        let path = image_dir.join(META_FILE);
+        let content = std::fs::read_to_string(&path).ok()?;
+        serde_json::from_str(&content).ok()
+    }
+
+    /// Age of the image in days. Returns None if timestamp can't be parsed.
+    pub fn age_days(&self) -> Option<u64> {
+        let built = time::OffsetDateTime::parse(
+            &self.built_at,
+            &time::format_description::well_known::Rfc3339,
+        )
+        .ok()?;
+        let now = time::OffsetDateTime::now_utc();
+        let duration: time::Duration = now - built;
+        #[allow(clippy::cast_sign_loss)] // Duration is always positive (now >= built)
+        Some(duration.whole_days().max(0) as u64)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip_dockerfile_source() {
+        let meta = ImageMeta::new(ImageSource::Dockerfile {
+            path: "Dockerfile".into(),
+        });
+        let json = serde_json::to_string(&meta).unwrap();
+        let parsed: ImageMeta = serde_json::from_str(&json).unwrap();
+        assert!(matches!(parsed.source, ImageSource::Dockerfile { .. }));
+        assert!(!parsed.built_at.is_empty());
+    }
+
+    #[test]
+    fn roundtrip_create_source() {
+        let meta = ImageMeta::new(ImageSource::Create {
+            packages: vec!["curl".into(), "git".into()],
+            run_commands: vec!["pip install flask".into()],
+        });
+        let json = serde_json::to_string(&meta).unwrap();
+        let parsed: ImageMeta = serde_json::from_str(&json).unwrap();
+        if let ImageSource::Create { packages, .. } = &parsed.source {
+            assert_eq!(packages, &["curl", "git"]);
+        } else {
+            panic!("wrong source type");
+        }
+    }
+
+    #[test]
+    fn age_days_is_zero_for_fresh_image() {
+        let meta = ImageMeta::new(ImageSource::Unknown);
+        let days = meta.age_days().unwrap();
+        assert_eq!(days, 0);
+    }
+
+    #[test]
+    fn save_and_load() {
+        let dir = tempfile::tempdir().unwrap();
+        let meta = ImageMeta::new(ImageSource::Docker {
+            image: "ubuntu:24.04".into(),
+        });
+        meta.save(dir.path()).unwrap();
+
+        let loaded = ImageMeta::load(dir.path()).unwrap();
+        assert!(matches!(loaded.source, ImageSource::Docker { .. }));
+    }
+
+    #[test]
+    fn load_returns_none_for_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(ImageMeta::load(dir.path()).is_none());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,5 +17,6 @@ pub mod proxy;
 pub mod secret;
 pub mod session;
 pub mod templates;
+pub mod terminal;
 pub mod tls;
 pub mod vm;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod dns;
 pub mod error;
 pub mod ffi;
 pub mod image;
+pub mod image_meta;
 pub mod net;
 pub mod provider;
 pub mod proxy;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 #![allow(clippy::must_use_candidate)]
 #![allow(clippy::module_name_repetitions)]
 
+pub mod auto_detect;
 pub mod ca;
 pub mod config;
 pub mod dns;

--- a/src/main.rs
+++ b/src/main.rs
@@ -594,6 +594,15 @@ fn exec_command(args: ExecArgs) {
                 eprintln!("image '{name}' not found. Run: redan image create {name} ...");
                 std::process::exit(1);
             }
+            // Warn about stale images (don't block execution)
+            if let Some(meta) = redan::image_meta::ImageMeta::load(&p)
+                && let Some(days) = meta.age_days()
+                && days > 30
+            {
+                eprintln!(
+                    "warning: image '{name}' is {days} days old. Run: redan image update {name}"
+                );
+            }
             p.to_string_lossy().into_owned()
         }
         (_, Some(path)) => path.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -511,14 +511,10 @@ fn exec_command(args: ExecArgs) {
         if let Some(auto) = redan::auto_detect::detect() {
             if auto.needs_image_build {
                 eprintln!("Building claude-code image (this may take a minute)...");
-                match image::import_dockerfile("claude-code", "dockerfiles/claude-code.dockerfile")
-                {
+                match build_bundled_claude_image() {
                     Ok(_) => eprintln!("Image claude-code built successfully."),
                     Err(e) => {
                         eprintln!("error: failed to build claude-code image: {e}");
-                        eprintln!(
-                            "  Build manually: redan image import claude-code --dockerfile dockerfiles/claude-code.dockerfile"
-                        );
                         std::process::exit(1);
                     }
                 }
@@ -734,16 +730,21 @@ fn exec_detached(
             });
     }
 
-    // Spawn daemon process
-    let exe = std::env::current_exe().unwrap_or_else(|e| {
-        eprintln!("cannot find redan executable: {e}");
+    // Spawn daemon process. If anything fails before the child starts,
+    // clean up the session dir (it contains daemon_config.json with secret specs).
+    let cleanup_and_exit = |msg: &str, err: &dyn std::fmt::Display| -> ! {
+        eprintln!("{msg}: {err}");
+        let _ = std::fs::remove_dir_all(&session_dir);
         std::process::exit(1);
+    };
+
+    let exe = std::env::current_exe().unwrap_or_else(|e| {
+        cleanup_and_exit("cannot find redan executable", &e);
     });
 
     let log_path = session_dir.join("redan.log");
     let log_file = std::fs::File::create(&log_path).unwrap_or_else(|e| {
-        eprintln!("cannot create log file: {e}");
-        std::process::exit(1);
+        cleanup_and_exit("cannot create log file", &e);
     });
 
     let mut child = std::process::Command::new(exe)
@@ -752,14 +753,12 @@ fn exec_detached(
         .arg(&session_id)
         .stdin(std::process::Stdio::null())
         .stdout(log_file.try_clone().unwrap_or_else(|e| {
-            eprintln!("cannot clone log file handle: {e}");
-            std::process::exit(1);
+            cleanup_and_exit("cannot clone log file handle", &e);
         }))
         .stderr(log_file)
         .spawn()
         .unwrap_or_else(|e| {
-            eprintln!("cannot spawn daemon: {e}");
-            std::process::exit(1);
+            cleanup_and_exit("cannot spawn daemon", &e);
         });
 
     let daemon_pid = child.id();
@@ -823,7 +822,7 @@ fn run_daemon(session_id: &str) {
 }
 
 fn attach_session(id_or_name: Option<&str>) {
-    let meta = session::find_session(id_or_name).unwrap_or_else(|| {
+    let mut meta = session::find_session(id_or_name).unwrap_or_else(|| {
         if let Some(q) = id_or_name {
             eprintln!("session '{q}' not found");
         } else {
@@ -837,15 +836,30 @@ fn attach_session(id_or_name: Option<&str>) {
         std::process::exit(1);
     }
 
-    let sock_path = meta.console_socket.unwrap_or_else(|| {
+    // The daemon may not have written the console socket path to meta.json yet.
+    // Retry briefly (up to 3s) before giving up.
+    let sock_path_str = 'retry: {
+        for _ in 0..10 {
+            if let Some(ref s) = meta.console_socket {
+                break 'retry s.clone();
+            }
+            std::thread::sleep(std::time::Duration::from_millis(300));
+            // Reload meta in case the daemon updated it
+            let meta_path = session::session_dir(&meta.id).join("meta.json");
+            if let Ok(json) = std::fs::read_to_string(&meta_path)
+                && let Ok(fresh) = serde_json::from_str::<session::SessionMeta>(&json)
+            {
+                meta = fresh;
+            }
+        }
         eprintln!(
             "session {} has no console socket (started without --detach?)",
             meta.id
         );
         std::process::exit(1);
-    });
+    };
 
-    let sock_path = std::path::Path::new(&sock_path);
+    let sock_path = std::path::Path::new(&sock_path_str);
     if !sock_path.exists() {
         eprintln!("console socket not found: {}", sock_path.display());
         std::process::exit(1);
@@ -1099,4 +1113,17 @@ fn logs(session_id: Option<&str>, follow: bool) {
             }
         }
     }
+}
+
+/// Build the claude-code image from the Dockerfile embedded in the binary.
+/// This avoids depending on CWD containing the redan source tree.
+fn build_bundled_claude_image() -> std::io::Result<std::path::PathBuf> {
+    static DOCKERFILE: &str = include_str!("../dockerfiles/claude-code.dockerfile");
+    let tmp = std::env::temp_dir().join("redan-claude-code-build");
+    std::fs::create_dir_all(&tmp)?;
+    let df_path = tmp.join("Dockerfile");
+    std::fs::write(&df_path, DOCKERFILE)?;
+    let result = image::import_dockerfile("claude-code", df_path.to_str().unwrap_or(""));
+    let _ = std::fs::remove_dir_all(&tmp);
+    result
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -498,7 +498,6 @@ fn exec_command(args: ExecArgs) {
         secret_file: &args.secret_file,
         mounts: &args.mounts,
         discover: args.discover,
-        detach: args.detach,
     });
 
     // Three paths:

--- a/src/main.rs
+++ b/src/main.rs
@@ -371,17 +371,20 @@ fn main() {
             None => {
                 let sessions = session::list_sessions();
                 if sessions.is_empty() {
-                    eprintln!("no sessions. Run: redan exec --image <name> -- <command>");
+                    eprintln!("no sessions. Run: redan exec");
                 } else {
                     for s in &sessions {
                         let status = session_status_label(s);
-                        println!(
-                            "{}  {:10} {:20} {}",
-                            s.id,
-                            status,
-                            s.image.as_deref().unwrap_or("-"),
-                            s.started_at,
-                        );
+                        let name = s.name.as_deref().unwrap_or("");
+                        let image = s.image.as_deref().unwrap_or("-");
+                        if name.is_empty() {
+                            println!("{}  {:10} {:20} {}", s.id, status, image, s.started_at,);
+                        } else {
+                            println!(
+                                "{}  {:10} {:20} {} ({})",
+                                s.id, status, image, s.started_at, name,
+                            );
+                        }
                     }
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -235,6 +235,8 @@ enum ImageAction {
     List,
     /// Remove an image
     Remove { name: String },
+    /// Rebuild an image from its original source
+    Update { name: String },
     /// Import from Docker image, Dockerfile, or devcontainer
     Import {
         /// Image name to create
@@ -341,10 +343,14 @@ fn main() {
                             continue;
                         };
                         let size = cmd::doctor::dir_size(&path);
-                        println!("{name:20} {}", cmd::doctor::humanize_bytes(size));
+                        let age = redan::image_meta::ImageMeta::load(&path)
+                            .and_then(|m| m.age_days())
+                            .map_or(String::new(), |d| format!("  ({d}d ago)"));
+                        println!("{name:20} {}{}", cmd::doctor::humanize_bytes(size), age);
                     }
                 }
             }
+            ImageAction::Update { name } => update_image(&name),
             ImageAction::Remove { name } => match image::remove(&name) {
                 Ok(()) => eprintln!("removed image '{name}'"),
                 Err(e) => {
@@ -914,6 +920,60 @@ fn stop_session(id_or_name: Option<&str>) {
         libc::kill(pid.cast_signed(), libc::SIGKILL);
     }
     eprintln!("session {} killed", meta.id);
+}
+
+fn update_image(name: &str) {
+    let path = match image::image_path(name) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("error: {e}");
+            std::process::exit(1);
+        }
+    };
+    if !path.exists() {
+        eprintln!("image '{name}' not found");
+        std::process::exit(1);
+    }
+
+    let meta = redan::image_meta::ImageMeta::load(&path).unwrap_or_else(|| {
+        eprintln!("image '{name}' has no build metadata (cannot determine how it was built)");
+        eprintln!("  remove and rebuild manually: redan image remove {name}");
+        std::process::exit(1);
+    });
+
+    eprintln!("updating image '{name}'...");
+
+    // Remove old image first
+    if let Err(e) = image::remove(name) {
+        eprintln!("cannot remove old image: {e}");
+        std::process::exit(1);
+    }
+
+    let result = match &meta.source {
+        redan::image_meta::ImageSource::Dockerfile { path } => image::import_dockerfile(name, path),
+        redan::image_meta::ImageSource::Docker { image: img } => image::import_docker(name, img),
+        redan::image_meta::ImageSource::Devcontainer { path } => {
+            let config_path = cmd::init::resolve_devcontainer_path(path);
+            image::import_devcontainer(name, &config_path)
+        }
+        redan::image_meta::ImageSource::Create {
+            packages,
+            run_commands,
+        } => image::create(name, packages, run_commands),
+        redan::image_meta::ImageSource::Unknown => {
+            eprintln!("image '{name}' was built from an unknown source, cannot update");
+            eprintln!("  remove and rebuild manually: redan image remove {name}");
+            std::process::exit(1);
+        }
+    };
+
+    match result {
+        Ok(_) => eprintln!("image '{name}' updated"),
+        Err(e) => {
+            eprintln!("update failed: {e}");
+            std::process::exit(1);
+        }
+    }
 }
 
 fn import_image(

--- a/src/main.rs
+++ b/src/main.rs
@@ -683,13 +683,21 @@ fn exec_detached(
     discover: bool,
     session_name: Option<&str>,
 ) {
-    // Create session directory and write daemon config
+    // Create session directory and write daemon config.
+    // Directory is 0o700 and config file is 0o600 because the config
+    // contains secret specs that are briefly on disk until the daemon
+    // reads and deletes them.
     let session_id = session::new_id();
     let session_dir = session::session_dir(&session_id);
     std::fs::create_dir_all(&session_dir).unwrap_or_else(|e| {
         eprintln!("cannot create session dir: {e}");
         std::process::exit(1);
     });
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&session_dir, std::fs::Permissions::from_mode(0o700));
+    }
 
     let daemon_cfg = DaemonConfig {
         rootfs: rootfs.into(),
@@ -710,10 +718,22 @@ fn exec_detached(
         eprintln!("cannot serialize daemon config: {e}");
         std::process::exit(1);
     });
-    std::fs::write(&config_path, &config_json).unwrap_or_else(|e| {
-        eprintln!("cannot write daemon config: {e}");
-        std::process::exit(1);
-    });
+    {
+        use std::io::Write;
+        #[cfg(unix)]
+        use std::os::unix::fs::OpenOptionsExt;
+
+        let mut opts = std::fs::OpenOptions::new();
+        opts.write(true).create_new(true);
+        #[cfg(unix)]
+        opts.mode(0o600);
+        opts.open(&config_path)
+            .and_then(|mut f| f.write_all(config_json.as_bytes()))
+            .unwrap_or_else(|e| {
+                eprintln!("cannot write daemon config: {e}");
+                std::process::exit(1);
+            });
+    }
 
     // Spawn daemon process
     let exe = std::env::current_exe().unwrap_or_else(|e| {
@@ -766,6 +786,10 @@ fn exec_detached(
 }
 
 fn run_daemon(session_id: &str) {
+    if !session::valid_session_id(session_id) {
+        eprintln!("invalid session ID: {session_id}");
+        std::process::exit(1);
+    }
     let session_dir = session::session_dir(session_id);
     let config_path = session_dir.join("daemon_config.json");
 
@@ -836,7 +860,10 @@ fn attach_session(id_or_name: Option<&str>) {
     });
 
     // Raw terminal mode for interactive I/O
-    let _raw_guard = redan::terminal::RawTerminalGuard::enter();
+    let _raw_guard = redan::terminal::RawTerminalGuard::enter().unwrap_or_else(|e| {
+        eprintln!("cannot enter raw terminal mode: {e}");
+        std::process::exit(1);
+    });
 
     // Relay between stdin/stdout and the console socket
     let reader = stream.try_clone().unwrap_or_else(|e| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -194,6 +194,14 @@ enum Cli {
         follow: bool,
     },
 
+    /// Internal: daemon process for detached sessions. Not user-facing.
+    #[command(hide = true)]
+    Daemon {
+        /// Session ID to run
+        #[arg(long)]
+        session: String,
+    },
+
     /// Generate redan.toml and image config for a project
     Init {
         /// Generate Claude Code devcontainer and config
@@ -300,6 +308,7 @@ fn main() {
         }
         Cli::Attach { session } => attach_session(session.as_deref()),
         Cli::Stop { session } => stop_session(session.as_deref()),
+        Cli::Daemon { session } => run_daemon(&session),
 
         Cli::Image { action } => match action {
             ImageAction::Create {
@@ -593,19 +602,182 @@ fn exec_command(args: ExecArgs) {
             "echo 'no command specified; use: redan exec --image <name> -- <command>'".to_string()
         }
     });
-    cmd::exec::run(&cmd::exec::ExecConfig {
-        rootfs: &rootfs_path,
-        command: &command,
-        interactive,
+    if args.detach {
+        exec_detached(
+            &rootfs_path,
+            &command,
+            timeout,
+            &secrets,
+            &allow_hosts,
+            &mounts,
+            audit_log.as_deref(),
+            image_name.as_deref(),
+            &cfg.env,
+            args.discover,
+            args.name.as_deref(),
+        );
+    } else {
+        cmd::exec::run(&cmd::exec::ExecConfig {
+            rootfs: &rootfs_path,
+            command: &command,
+            interactive,
+            timeout_secs: timeout,
+            secret_specs: &secrets,
+            allow_host_specs: &allow_hosts,
+            mount_specs: &mounts,
+            audit_log_path: audit_log.as_deref(),
+            image_name: image_name.as_deref(),
+            guest_env: &cfg.env,
+            discover: args.discover,
+            session_name: args.name.as_deref(),
+            session_id: None,
+        });
+    }
+}
+
+/// Serializable exec config for passing to the daemon process.
+#[derive(serde::Serialize, serde::Deserialize)]
+struct DaemonConfig {
+    rootfs: String,
+    command: String,
+    timeout_secs: u64,
+    secrets: Vec<String>,
+    allow_hosts: Vec<String>,
+    mounts: Vec<String>,
+    audit_log: Option<String>,
+    image_name: Option<String>,
+    env: std::collections::BTreeMap<String, String>,
+    discover: bool,
+    session_name: Option<String>,
+}
+
+#[allow(clippy::too_many_arguments)]
+fn exec_detached(
+    rootfs: &str,
+    command: &str,
+    timeout: u64,
+    secrets: &[String],
+    allow_hosts: &[String],
+    mounts: &[String],
+    audit_log: Option<&str>,
+    image_name: Option<&str>,
+    env: &std::collections::BTreeMap<String, String>,
+    discover: bool,
+    session_name: Option<&str>,
+) {
+    // Create session directory and write daemon config
+    let session_id = session::new_id();
+    let session_dir = session::session_dir(&session_id);
+    std::fs::create_dir_all(&session_dir).unwrap_or_else(|e| {
+        eprintln!("cannot create session dir: {e}");
+        std::process::exit(1);
+    });
+
+    let daemon_cfg = DaemonConfig {
+        rootfs: rootfs.into(),
+        command: command.into(),
         timeout_secs: timeout,
-        secret_specs: &secrets,
-        allow_host_specs: &allow_hosts,
-        mount_specs: &mounts,
-        audit_log_path: audit_log.as_deref(),
-        image_name: image_name.as_deref(),
+        secrets: secrets.to_vec(),
+        allow_hosts: allow_hosts.to_vec(),
+        mounts: mounts.to_vec(),
+        audit_log: audit_log.map(Into::into),
+        image_name: image_name.map(Into::into),
+        env: env.clone(),
+        discover,
+        session_name: session_name.map(Into::into),
+    };
+
+    let config_path = session_dir.join("daemon_config.json");
+    let config_json = serde_json::to_string(&daemon_cfg).unwrap_or_else(|e| {
+        eprintln!("cannot serialize daemon config: {e}");
+        std::process::exit(1);
+    });
+    std::fs::write(&config_path, &config_json).unwrap_or_else(|e| {
+        eprintln!("cannot write daemon config: {e}");
+        std::process::exit(1);
+    });
+
+    // Spawn daemon process
+    let exe = std::env::current_exe().unwrap_or_else(|e| {
+        eprintln!("cannot find redan executable: {e}");
+        std::process::exit(1);
+    });
+
+    let log_path = session_dir.join("redan.log");
+    let log_file = std::fs::File::create(&log_path).unwrap_or_else(|e| {
+        eprintln!("cannot create log file: {e}");
+        std::process::exit(1);
+    });
+
+    let mut child = std::process::Command::new(exe)
+        .arg("daemon")
+        .arg("--session")
+        .arg(&session_id)
+        .stdin(std::process::Stdio::null())
+        .stdout(log_file.try_clone().unwrap_or_else(|e| {
+            eprintln!("cannot clone log file handle: {e}");
+            std::process::exit(1);
+        }))
+        .stderr(log_file)
+        .spawn()
+        .unwrap_or_else(|e| {
+            eprintln!("cannot spawn daemon: {e}");
+            std::process::exit(1);
+        });
+
+    let daemon_pid = child.id();
+
+    // Detach from child: parent exits soon, daemon gets reparented to init.
+    // Spawn a thread to wait() so we don't leave a zombie if parent lingers.
+    std::thread::spawn(move || {
+        let _ = child.wait();
+    });
+
+    // Write initial session metadata
+    let mut meta = session::SessionMeta::new(&session_id, image_name, Some(command));
+    meta.pid = Some(daemon_pid);
+    meta.name = session_name.map(Into::into);
+    if let Err(e) = meta.save() {
+        eprintln!("warning: cannot save session metadata: {e}");
+    }
+
+    let name_display = session_name.map_or(String::new(), |n| format!(" ({n})"));
+    eprintln!("session {session_id}{name_display} started (detached)");
+    eprintln!("  redan logs {session_id} -f  tail logs");
+    eprintln!("  redan stop {session_id}     stop session");
+}
+
+fn run_daemon(session_id: &str) {
+    let session_dir = session::session_dir(session_id);
+    let config_path = session_dir.join("daemon_config.json");
+
+    let config_json = std::fs::read_to_string(&config_path).unwrap_or_else(|e| {
+        eprintln!("cannot read daemon config: {e}");
+        std::process::exit(1);
+    });
+    let cfg: DaemonConfig = serde_json::from_str(&config_json).unwrap_or_else(|e| {
+        eprintln!("invalid daemon config: {e}");
+        std::process::exit(1);
+    });
+
+    // Clean up the config file — it contains secret specs
+    let _ = std::fs::remove_file(&config_path);
+
+    // Run the VM+proxy (non-interactive: daemon has no terminal)
+    cmd::exec::run(&cmd::exec::ExecConfig {
+        rootfs: &cfg.rootfs,
+        command: &cfg.command,
+        interactive: false,
+        timeout_secs: cfg.timeout_secs,
+        secret_specs: &cfg.secrets,
+        allow_host_specs: &cfg.allow_hosts,
+        mount_specs: &cfg.mounts,
+        audit_log_path: cfg.audit_log.as_deref(),
+        image_name: cfg.image_name.as_deref(),
         guest_env: &cfg.env,
-        discover: args.discover,
-        session_name: args.name.as_deref(),
+        discover: cfg.discover,
+        session_name: cfg.session_name.as_deref(),
+        session_id: Some(session_id),
     });
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,6 +151,26 @@ enum Cli {
         /// Run once to find out what hosts the agent needs, then lock down.
         #[arg(long)]
         discover: bool,
+
+        /// Run session in the background. Use `redan attach` to reconnect.
+        #[arg(long, short = 'd')]
+        detach: bool,
+
+        /// Name this session for easy reference (e.g., `redan attach my-agent`).
+        #[arg(long)]
+        name: Option<String>,
+    },
+
+    /// Attach to a running session
+    Attach {
+        /// Session ID or name (default: most recent running session)
+        session: Option<String>,
+    },
+
+    /// Stop a running session
+    Stop {
+        /// Session ID or name (default: most recent running session)
+        session: Option<String>,
     },
 
     /// Manage rootfs images
@@ -259,6 +279,8 @@ fn main() {
             audit_log,
             log_file: _,
             discover,
+            detach,
+            name,
         } => {
             exec_command(ExecArgs {
                 image_name,
@@ -272,8 +294,12 @@ fn main() {
                 mounts,
                 audit_log,
                 discover,
+                detach,
+                name,
             });
         }
+        Cli::Attach { session } => attach_session(session.as_deref()),
+        Cli::Stop { session } => stop_session(session.as_deref()),
 
         Cli::Image { action } => match action {
             ImageAction::Create {
@@ -436,6 +462,8 @@ struct ExecArgs {
     mounts: Vec<String>,
     audit_log: Option<String>,
     discover: bool,
+    detach: bool,
+    name: Option<String>,
 }
 
 fn exec_command(args: ExecArgs) {
@@ -444,15 +472,16 @@ fn exec_command(args: ExecArgs) {
         eprintln!("config: {}", path.display());
     }
 
-    let explicit = redan::auto_detect::has_explicit_flags(
-        &args.image_name,
-        &args.rootfs,
-        &args.command,
-        &args.secrets,
-        &args.secret_file,
-        &args.mounts,
-        args.discover,
-    );
+    let explicit = redan::auto_detect::has_explicit_flags(&redan::auto_detect::ExecFlags {
+        image: &args.image_name,
+        rootfs: &args.rootfs,
+        command: &args.command,
+        secrets: &args.secrets,
+        secret_file: &args.secret_file,
+        mounts: &args.mounts,
+        discover: args.discover,
+        detach: args.detach,
+    });
 
     // Three paths:
     // 1. Config file exists → use it (existing behavior)
@@ -576,7 +605,140 @@ fn exec_command(args: ExecArgs) {
         image_name: image_name.as_deref(),
         guest_env: &cfg.env,
         discover: args.discover,
+        session_name: args.name.as_deref(),
     });
+}
+
+fn attach_session(id_or_name: Option<&str>) {
+    let meta = session::find_session(id_or_name).unwrap_or_else(|| {
+        if let Some(q) = id_or_name {
+            eprintln!("session '{q}' not found");
+        } else {
+            eprintln!("no sessions found");
+        }
+        std::process::exit(1);
+    });
+
+    if !meta.is_alive() {
+        eprintln!("session {} is not running", meta.id);
+        std::process::exit(1);
+    }
+
+    let sock_path = meta.console_socket.unwrap_or_else(|| {
+        eprintln!(
+            "session {} has no console socket (started without --detach?)",
+            meta.id
+        );
+        std::process::exit(1);
+    });
+
+    let sock_path = std::path::Path::new(&sock_path);
+    if !sock_path.exists() {
+        eprintln!("console socket not found: {}", sock_path.display());
+        std::process::exit(1);
+    }
+
+    eprintln!("attaching to session {} ...", meta.id);
+
+    let stream = std::os::unix::net::UnixStream::connect(sock_path).unwrap_or_else(|e| {
+        eprintln!("cannot connect to console: {e}");
+        std::process::exit(1);
+    });
+
+    // Raw terminal mode for interactive I/O
+    let _raw_guard = redan::terminal::RawTerminalGuard::enter();
+
+    // Relay between stdin/stdout and the console socket
+    let reader = stream.try_clone().unwrap_or_else(|e| {
+        eprintln!("cannot clone socket: {e}");
+        std::process::exit(1);
+    });
+
+    // Socket → stdout
+    let stdout_thread = std::thread::spawn(move || {
+        use std::io::Read;
+        let mut reader = reader;
+        let mut buf = [0u8; 4096];
+        loop {
+            match reader.read(&mut buf) {
+                Ok(0) | Err(_) => break,
+                Ok(n) => {
+                    use std::io::Write;
+                    let _ = std::io::stdout().write_all(&buf[..n]);
+                    let _ = std::io::stdout().flush();
+                }
+            }
+        }
+    });
+
+    // stdin → socket
+    {
+        use std::io::Read;
+        let mut writer = stream;
+        let mut buf = [0u8; 4096];
+        loop {
+            match std::io::stdin().read(&mut buf) {
+                Ok(0) | Err(_) => break,
+                Ok(n) => {
+                    use std::io::Write;
+                    if writer.write_all(&buf[..n]).is_err() {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    let _ = stdout_thread.join();
+    eprintln!("\ndetached from session {}", meta.id);
+}
+
+fn stop_session(id_or_name: Option<&str>) {
+    let meta = session::find_session(id_or_name).unwrap_or_else(|| {
+        if let Some(q) = id_or_name {
+            eprintln!("session '{q}' not found");
+        } else {
+            eprintln!("no sessions found");
+        }
+        std::process::exit(1);
+    });
+
+    if !meta.is_alive() {
+        eprintln!("session {} is not running", meta.id);
+        std::process::exit(1);
+    }
+
+    let pid = meta.pid.unwrap_or_else(|| {
+        eprintln!("session {} has no pid recorded", meta.id);
+        std::process::exit(1);
+    });
+
+    eprintln!("stopping session {} (pid {pid})...", meta.id);
+
+    // Send SIGTERM for graceful shutdown
+    let ret = unsafe { libc::kill(pid.cast_signed(), libc::SIGTERM) };
+    if ret != 0 {
+        eprintln!(
+            "failed to send SIGTERM: {}",
+            std::io::Error::last_os_error()
+        );
+        std::process::exit(1);
+    }
+
+    // Wait briefly for exit, then SIGKILL
+    for _ in 0..30 {
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        if !meta.is_alive() {
+            eprintln!("session {} stopped", meta.id);
+            return;
+        }
+    }
+
+    eprintln!("session {} did not exit, sending SIGKILL", meta.id);
+    unsafe {
+        libc::kill(pid.cast_signed(), libc::SIGKILL);
+    }
+    eprintln!("session {} killed", meta.id);
 }
 
 fn import_image(

--- a/src/main.rs
+++ b/src/main.rs
@@ -260,89 +260,17 @@ fn main() {
             log_file: _,
             discover,
         } => {
-            let cfg = config::find_and_load();
-            if let Some((path, _)) = &cfg {
-                eprintln!("config: {}", path.display());
-            }
-            let cfg = cfg.map(|(_, c)| c).unwrap_or_default();
-
-            let mut all_secrets = cmd::exec::collect_secret_specs(&secrets, secret_file.as_deref());
-            all_secrets.extend(cfg.secret_specs());
-            let secrets = all_secrets;
-
-            let image_name = image_name.or_else(|| cfg.image.clone());
-            let rootfs = rootfs.or_else(|| cfg.rootfs.clone());
-            // Trailing args after -- joined into a shell command.
-            // Falls back to config file, then /bin/sh for interactive.
-            let command = if command.is_empty() {
-                cfg.command.clone()
-            } else {
-                Some(shell_words::join(&command))
-            };
-            let timeout = timeout.or(cfg.timeout).unwrap_or(3600);
-            let interactive = interactive || cfg.interactive.unwrap_or(false);
-            let audit_log = audit_log.or_else(|| cfg.audit_log.clone());
-
-            let mut allow_hosts = allow_hosts;
-            allow_hosts.extend(cfg.network.allow.clone());
-
-            // Import allowedDomains from Claude Code settings if present.
-            // Lets users define network policy once in .claude/settings.json
-            // and have redan enforce it with real VM isolation.
-            let claude_domains = config::claude_allowed_domains();
-            if !claude_domains.is_empty() {
-                log::info!(
-                    "imported {} domains from Claude Code settings",
-                    claude_domains.len()
-                );
-                allow_hosts.extend(claude_domains);
-            }
-
-            let mut mounts = mounts;
-            mounts.extend(cfg.mount_specs());
-
-            let rootfs_path = match (&image_name, &rootfs) {
-                (Some(name), _) => {
-                    let p = match image::image_path(name) {
-                        Ok(p) => p,
-                        Err(e) => {
-                            eprintln!("error: {e}");
-                            std::process::exit(1);
-                        }
-                    };
-                    if !p.exists() {
-                        eprintln!("image '{name}' not found. Run: redan image create {name} ...");
-                        std::process::exit(1);
-                    }
-                    p.to_string_lossy().into_owned()
-                }
-                (_, Some(path)) => path.clone(),
-                (None, None) => {
-                    eprintln!("no image specified. Set image in redan.toml or pass --image <name>");
-                    eprintln!("  redan init          generate a redan.toml");
-                    eprintln!("  redan image list    show available images");
-                    std::process::exit(1);
-                }
-            };
-            let command = command.unwrap_or_else(|| {
-                if interactive {
-                    "/bin/sh".to_string()
-                } else {
-                    "echo 'no command specified; use: redan exec --image <name> -- <command>'"
-                        .to_string()
-                }
-            });
-            cmd::exec::run(&cmd::exec::ExecConfig {
-                rootfs: &rootfs_path,
-                command: &command,
+            exec_command(ExecArgs {
+                image_name,
+                rootfs,
+                command,
                 interactive,
-                timeout_secs: timeout,
-                secret_specs: &secrets,
-                allow_host_specs: &allow_hosts,
-                mount_specs: &mounts,
-                audit_log_path: audit_log.as_deref(),
-                image_name: image_name.as_deref(),
-                guest_env: &cfg.env,
+                timeout,
+                secrets,
+                secret_file,
+                allow_hosts,
+                mounts,
+                audit_log,
                 discover,
             });
         }
@@ -494,6 +422,161 @@ fn main() {
             }
         },
     }
+}
+
+struct ExecArgs {
+    image_name: Option<String>,
+    rootfs: Option<String>,
+    command: Vec<String>,
+    interactive: bool,
+    timeout: Option<u64>,
+    secrets: Vec<String>,
+    secret_file: Option<String>,
+    allow_hosts: Vec<String>,
+    mounts: Vec<String>,
+    audit_log: Option<String>,
+    discover: bool,
+}
+
+fn exec_command(args: ExecArgs) {
+    let config_file = config::find_and_load();
+    if let Some((ref path, _)) = config_file {
+        eprintln!("config: {}", path.display());
+    }
+
+    let explicit = redan::auto_detect::has_explicit_flags(
+        &args.image_name,
+        &args.rootfs,
+        &args.command,
+        &args.secrets,
+        &args.secret_file,
+        &args.mounts,
+        args.discover,
+    );
+
+    // Three paths:
+    // 1. Config file exists → use it (existing behavior)
+    // 2. Explicit CLI flags → use them (existing behavior)
+    // 3. Neither → try auto-detect
+    let cfg = if let Some((_, cfg)) = config_file {
+        cfg
+    } else if !explicit {
+        // No config, no explicit flags: try auto-detect
+        if let Some(auto) = redan::auto_detect::detect() {
+            if auto.needs_image_build {
+                eprintln!("Building claude-code image (this may take a minute)...");
+                match image::import_dockerfile("claude-code", "dockerfiles/claude-code.dockerfile")
+                {
+                    Ok(_) => eprintln!("Image claude-code built successfully."),
+                    Err(e) => {
+                        eprintln!("error: failed to build claude-code image: {e}");
+                        eprintln!(
+                            "  Build manually: redan image import claude-code --dockerfile dockerfiles/claude-code.dockerfile"
+                        );
+                        std::process::exit(1);
+                    }
+                }
+            }
+            for msg in &auto.messages {
+                eprintln!("  {msg}");
+            }
+            auto.config
+        } else {
+            eprintln!("no redan.toml found and auto-detect failed.");
+            eprintln!();
+            if std::env::var("ANTHROPIC_API_KEY").is_err() {
+                eprintln!("  Set ANTHROPIC_API_KEY to auto-detect Claude Code:");
+                eprintln!("    export ANTHROPIC_API_KEY=sk-ant-...");
+                eprintln!();
+            }
+            eprintln!("  Or create a config:");
+            eprintln!("    redan init          generate a redan.toml");
+            eprintln!("    redan init --claude  generate config + devcontainer for Claude Code");
+            eprintln!();
+            eprintln!("  Or specify an image directly:");
+            eprintln!("    redan exec --image <name> -- <command>");
+            eprintln!("    redan image list    show available images");
+            std::process::exit(1);
+        }
+    } else {
+        config::Config::default()
+    };
+
+    let mut all_secrets =
+        cmd::exec::collect_secret_specs(&args.secrets, args.secret_file.as_deref());
+    all_secrets.extend(cfg.secret_specs());
+    let secrets = all_secrets;
+
+    let image_name = args.image_name.or_else(|| cfg.image.clone());
+    let rootfs = args.rootfs.or_else(|| cfg.rootfs.clone());
+    let command = if args.command.is_empty() {
+        cfg.command.clone()
+    } else {
+        Some(shell_words::join(&args.command))
+    };
+    let timeout = args.timeout.or(cfg.timeout).unwrap_or(3600);
+    let interactive = args.interactive || cfg.interactive.unwrap_or(false);
+    let audit_log = args.audit_log.or_else(|| cfg.audit_log.clone());
+
+    let mut allow_hosts = args.allow_hosts;
+    allow_hosts.extend(cfg.network.allow.clone());
+
+    // Import allowedDomains from Claude Code settings if present.
+    let claude_domains = config::claude_allowed_domains();
+    if !claude_domains.is_empty() {
+        log::info!(
+            "imported {} domains from Claude Code settings",
+            claude_domains.len()
+        );
+        allow_hosts.extend(claude_domains);
+    }
+
+    let mut mounts = args.mounts;
+    mounts.extend(cfg.mount_specs());
+
+    let rootfs_path = match (&image_name, &rootfs) {
+        (Some(name), _) => {
+            let p = match image::image_path(name) {
+                Ok(p) => p,
+                Err(e) => {
+                    eprintln!("error: {e}");
+                    std::process::exit(1);
+                }
+            };
+            if !p.exists() {
+                eprintln!("image '{name}' not found. Run: redan image create {name} ...");
+                std::process::exit(1);
+            }
+            p.to_string_lossy().into_owned()
+        }
+        (_, Some(path)) => path.clone(),
+        (None, None) => {
+            eprintln!("no image specified. Set image in redan.toml or pass --image <name>");
+            eprintln!("  redan init          generate a redan.toml");
+            eprintln!("  redan image list    show available images");
+            std::process::exit(1);
+        }
+    };
+    let command = command.unwrap_or_else(|| {
+        if interactive {
+            "/bin/sh".to_string()
+        } else {
+            "echo 'no command specified; use: redan exec --image <name> -- <command>'".to_string()
+        }
+    });
+    cmd::exec::run(&cmd::exec::ExecConfig {
+        rootfs: &rootfs_path,
+        command: &command,
+        interactive,
+        timeout_secs: timeout,
+        secret_specs: &secrets,
+        allow_host_specs: &allow_hosts,
+        mount_specs: &mounts,
+        audit_log_path: audit_log.as_deref(),
+        image_name: image_name.as_deref(),
+        guest_env: &cfg.env,
+        discover: args.discover,
+    });
 }
 
 fn import_image(

--- a/src/main.rs
+++ b/src/main.rs
@@ -978,9 +978,21 @@ fn update_image(name: &str) {
 
     eprintln!("updating image '{name}'...");
 
-    // Remove old image first
-    if let Err(e) = image::remove(name) {
-        eprintln!("cannot remove old image: {e}");
+    if matches!(meta.source, redan::image_meta::ImageSource::Unknown) {
+        eprintln!("image '{name}' was built from an unknown source, cannot update");
+        eprintln!("  remove and rebuild manually: redan image remove {name}");
+        std::process::exit(1);
+    }
+
+    // Move old image aside so we can restore it if the rebuild fails.
+    // The build functions require the destination not to exist.
+    let backup = {
+        let mut b = path.clone();
+        b.set_extension("bak");
+        b
+    };
+    if let Err(e) = std::fs::rename(&path, &backup) {
+        eprintln!("cannot back up old image: {e}");
         std::process::exit(1);
     }
 
@@ -995,17 +1007,23 @@ fn update_image(name: &str) {
             packages,
             run_commands,
         } => image::create(name, packages, run_commands),
-        redan::image_meta::ImageSource::Unknown => {
-            eprintln!("image '{name}' was built from an unknown source, cannot update");
-            eprintln!("  remove and rebuild manually: redan image remove {name}");
-            std::process::exit(1);
-        }
+        redan::image_meta::ImageSource::Unknown => unreachable!(),
     };
 
     match result {
-        Ok(_) => eprintln!("image '{name}' updated"),
+        Ok(_) => {
+            let _ = std::fs::remove_dir_all(&backup);
+            eprintln!("image '{name}' updated");
+        }
         Err(e) => {
             eprintln!("update failed: {e}");
+            // Restore the old image so the user isn't left with nothing
+            if let Err(restore_err) = std::fs::rename(&backup, &path) {
+                eprintln!("cannot restore old image: {restore_err}");
+                eprintln!("  backup is at: {}", backup.display());
+            } else {
+                eprintln!("old image restored");
+            }
             std::process::exit(1);
         }
     }

--- a/src/session.rs
+++ b/src/session.rs
@@ -75,7 +75,7 @@ pub fn audit_log_path(id: &str) -> PathBuf {
 }
 
 /// Session metadata, written to `meta.json`.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SessionMeta {
     pub id: String,
     pub image: Option<String>,
@@ -84,9 +84,15 @@ pub struct SessionMeta {
     pub status: SessionStatus,
     #[serde(default)]
     pub pid: Option<u32>,
+    /// Path to the unix socket for console I/O (detached sessions).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub console_socket: Option<String>,
+    /// Optional human-friendly name for the session.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum SessionStatus {
     Running,
@@ -106,6 +112,8 @@ impl SessionMeta {
             started_at,
             status: SessionStatus::Running,
             pid: Some(std::process::id()),
+            console_socket: None,
+            name: None,
         }
     }
 
@@ -135,6 +143,38 @@ impl SessionMeta {
         };
         let _ = self.save();
     }
+}
+
+/// Path to the console unix socket for a session.
+pub fn console_socket_path(id: &str) -> std::path::PathBuf {
+    session_dir(id).join("console.sock")
+}
+
+/// Find a session by ID prefix or name. Returns the full session metadata.
+pub fn find_session(id_or_name: Option<&str>) -> Option<SessionMeta> {
+    let sessions = list_sessions();
+    let Some(query) = id_or_name else {
+        // No query: return most recent running session, or most recent overall
+        return sessions
+            .iter()
+            .find(|s| matches!(s.status, SessionStatus::Running) && s.is_alive())
+            .or_else(|| sessions.first())
+            .cloned();
+    };
+
+    // Try exact ID match
+    if let Some(s) = sessions.iter().find(|s| s.id == query) {
+        return Some(s.clone());
+    }
+    // Try ID prefix match
+    if let Some(s) = sessions.iter().find(|s| s.id.starts_with(query)) {
+        return Some(s.clone());
+    }
+    // Try name match
+    sessions
+        .iter()
+        .find(|s| s.name.as_deref() == Some(query))
+        .cloned()
 }
 
 /// List recent sessions, newest first.

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -1,0 +1,31 @@
+//! Terminal handling utilities.
+
+/// RAII guard: raw terminal mode on creation, restore on drop.
+pub struct RawTerminalGuard {
+    original: libc::termios,
+}
+
+impl RawTerminalGuard {
+    pub fn enter() -> Self {
+        unsafe {
+            let mut original: libc::termios = std::mem::zeroed();
+            libc::tcgetattr(libc::STDIN_FILENO, std::ptr::from_mut(&mut original));
+            let mut raw = original;
+            libc::cfmakeraw(std::ptr::from_mut(&mut raw));
+            libc::tcsetattr(libc::STDIN_FILENO, libc::TCSANOW, std::ptr::from_ref(&raw));
+            Self { original }
+        }
+    }
+}
+
+impl Drop for RawTerminalGuard {
+    fn drop(&mut self) {
+        unsafe {
+            libc::tcsetattr(
+                libc::STDIN_FILENO,
+                libc::TCSANOW,
+                std::ptr::from_ref(&self.original),
+            );
+        }
+    }
+}

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -1,19 +1,37 @@
 //! Terminal handling utilities.
 
+use std::io;
+
 /// RAII guard: raw terminal mode on creation, restore on drop.
 pub struct RawTerminalGuard {
     original: libc::termios,
 }
 
 impl RawTerminalGuard {
-    pub fn enter() -> Self {
+    /// Switch stdin to raw mode. Returns an error if stdin is not a TTY
+    /// or the termios syscalls fail.
+    pub fn enter() -> io::Result<Self> {
         unsafe {
-            let mut original: libc::termios = std::mem::zeroed();
-            libc::tcgetattr(libc::STDIN_FILENO, std::ptr::from_mut(&mut original));
+            // SAFETY: isatty, tcgetattr, tcsetattr are POSIX-specified and
+            // safe to call with STDIN_FILENO. MaybeUninit avoids reading
+            // uninitialized memory if tcgetattr fails.
+            if libc::isatty(libc::STDIN_FILENO) != 1 {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "stdin is not a TTY",
+                ));
+            }
+            let mut original = std::mem::MaybeUninit::<libc::termios>::uninit();
+            if libc::tcgetattr(libc::STDIN_FILENO, original.as_mut_ptr()) != 0 {
+                return Err(io::Error::last_os_error());
+            }
+            let original = original.assume_init();
             let mut raw = original;
             libc::cfmakeraw(std::ptr::from_mut(&mut raw));
-            libc::tcsetattr(libc::STDIN_FILENO, libc::TCSANOW, std::ptr::from_ref(&raw));
-            Self { original }
+            if libc::tcsetattr(libc::STDIN_FILENO, libc::TCSANOW, std::ptr::from_ref(&raw)) != 0 {
+                return Err(io::Error::last_os_error());
+            }
+            Ok(Self { original })
         }
     }
 }


### PR DESCRIPTION
Using redan today means `redan init --claude`, building an image, editing `redan.toml` to add secrets, then finally `redan exec`. Nobody does that daily. This PR makes it so `redan exec` in any project directory just works.

### Zero-config

When there's no `redan.toml` and no CLI flags, `redan exec` now auto-detects: checks for the `claude-code` image + `ANTHROPIC_API_KEY` in your environment, then runs Claude Code with sensible defaults (mounts cwd, allows Anthropic hosts, interactive mode). If the image is missing, it builds it from the bundled Dockerfile first. `~/.gitconfig` and `~/.ssh` get mounted so git works without setup.

Prints what it chose so nothing is silent:

```
  Using image: claude-code
  Injecting ANTHROPIC_API_KEY for api.anthropic.com
  Mounting ~/.gitconfig (read-only)
  Mounting current directory → /workspace
```

The detection logic lives in `auto_detect.rs` with 9 unit tests. If auto-detect fails (no API key, no known image), the error message tells you exactly what to do next.

### Session lifecycle

Sessions are now objects you can manage, not fire-and-forget processes.

- `redan exec -d` / `--detach` spawns a background daemon process and returns immediately
- `redan exec --name my-agent` gives sessions human-friendly names
- `redan stop my-agent` sends SIGTERM, waits 3s, then SIGKILL
- `redan attach my-agent` connects to the console socket (wired up for future console relay)
- `redan sessions` shows names and distinguishes running vs exited
- Lookup works by ID prefix or name

The daemon is a hidden `redan daemon --session <id>` subcommand. The parent serializes the resolved exec config to the session directory, spawns the daemon, and exits. The daemon reads it, cleans it up (it contains secret specs), and runs the VM+proxy.

### Image freshness

Images now store `.redan-image.json` with a build timestamp and source info (Dockerfile path, Docker image name, devcontainer path, or create args). This enables:

- `redan image list` shows age in days
- `redan image update claude-code` rebuilds from the original source
- `redan doctor` warns on images older than 30 days
- `redan exec` prints a non-blocking warning before launching with a stale image

### Housekeeping

`RawTerminalGuard` was duplicated between `cmd/exec.rs` and `main.rs`. Extracted to a shared `terminal` module. New modules: `auto_detect`, `image_meta`, `terminal`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Zero‑config Claude Code auto-detection and workflow; detached/background runs, attach/stop, named sessions, and richer session listing
  * Exec supports reusing/specifying sessions and improved interactive handling with graceful fallback
  * Image metadata with provenance tracking and an update-from-source action

* **Bug Fixes / Checks**
  * Doctor warns when ANTHROPIC_API_KEY is missing and flags aged images

* **Documentation**
  * README expanded with zero‑config, manual import, sessions, secrets, image freshness, and examples
<!-- end of auto-generated comment: release notes by coderabbit.ai -->