### PR TITLE
fix(security): harden auto-detect mounts and daemon config handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,9 +120,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.15.4"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7b6141e96a8c160799cc2d5adecd5cbbe5054cb8c7c4af53da0f83bb7ad256"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -130,9 +130,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.37.1"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b092fe214090261288111db7a2b2c2118e5a7f30dc2569f1732c4069a6840549"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
 dependencies = [
  "cc",
  "cmake",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,9 +939,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/README.md
+++ b/README.md
@@ -35,11 +35,15 @@ injection, it has no secret to steal and nowhere to send it.
 
 # What's Redan?
 
-Redan runs AI coding agents inside [libkrun] microVMs with network-layer
-secret injection. Agents get a real dev environment -- node, git, python,
-your project files -- but can't see host credentials and never observe
-the real values of injected secrets. Secrets are only injected for hosts
-you explicitly allow.
+Redan uses [libkrun] microVMs (sub-second boot) and a userspace TCP/IP
+stack to sandbox AI agents. The agent gets a full Linux environment with
+your project files mounted in, but runs in its own VM with its own
+filesystem and a network proxy that enforces a host allowlist. Secrets
+are injected into HTTPS request headers by the proxy on the host side,
+so they never exist inside the VM.
+
+Works with Claude Code, Codex, Copilot, Cursor, or any command-line AI
+agent.
 
 > *redan (/ɹɪˈdan/): a V-shaped fieldwork forming a salient angle toward
 > the enemy.*

--- a/README.md
+++ b/README.md
@@ -83,15 +83,15 @@ It prints what it chose so nothing is silent:
 ```text
   Using image: claude-code
   Injecting ANTHROPIC_API_KEY for api.anthropic.com
-  Mounting ~/.gitconfig
-  Mounting ~/.ssh
   Mounting current directory → /workspace
 ```
 
 Auto-detect kicks in when there's no `redan.toml` and no explicit CLI
-flags. Your `~/.gitconfig` and `~/.ssh` are mounted into the VM
-automatically, and git remote hosts are added to the network allowlist
-so git works out of the box.
+flags. Git remote hosts are added to the network allowlist so git works
+out of the box. Host files like `~/.ssh` and `~/.gitconfig` are not
+mounted by default (they'd be writable by the guest). Add them via
+`redan.toml` if you need them -- `redan init` generates commented-out
+examples.
 
 ### With redan.toml
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,29 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-BSD--3--Clause-blue.svg" alt="License: BSD-3-Clause"></a>
 </p>
 
+## Why redan?
+
+AI coding agents have your shell, your filesystem, your API keys, and
+full network access. That's fine until:
+
+- A prompt injection hidden in a dependency's README or issue comment
+  tells the agent to exfiltrate your API keys
+- The agent modifies `~/.ssh/authorized_keys`, `~/.gitconfig`, or
+  installs packages on your host
+- Malicious instructions in code the agent reads make it open
+  connections to hosts you never approved
+
+These aren't hypothetical. Every file the agent reads is a potential
+injection vector, and LLM prompt injection is an open problem with no
+general solution.
+
+Redan puts the agent in a microVM that boots in under a second. The
+agent gets a real dev environment, but it's isolated from your host.
+Own filesystem, own network, only the hosts you allow. Your API keys
+never enter the VM. Redan injects them at the network layer, only for
+the hosts you permit. Even if the agent is compromised by a prompt
+injection, it has no secret to steal and nowhere to send it.
+
 # What's Redan?
 
 Redan runs AI coding agents inside [libkrun] microVMs with network-layer

--- a/README.md
+++ b/README.md
@@ -3,6 +3,13 @@
   <p align="center">Your agents run free. Your secrets stay put.</p>
 </p>
 
+<p align="center">
+  <a href="https://github.com/getredan/redan/actions/workflows/ci.yml"><img src="https://github.com/getredan/redan/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://github.com/getredan/redan/actions/workflows/security-audit.yml"><img src="https://github.com/getredan/redan/actions/workflows/security-audit.yml/badge.svg" alt="Security Audit"></a>
+  <a href="https://github.com/getredan/redan/releases"><img src="https://img.shields.io/github/v/release/getredan/redan" alt="Release"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-BSD--3--Clause-blue.svg" alt="License: BSD-3-Clause"></a>
+</p>
+
 # What's Redan?
 
 Redan runs AI coding agents inside [libkrun] microVMs with network-layer

--- a/src/auto_detect.rs
+++ b/src/auto_detect.rs
@@ -5,8 +5,6 @@
 //! setups: if the `claude-code` image exists and `ANTHROPIC_API_KEY` is set,
 //! redan runs Claude Code with smart defaults.
 
-use std::path::Path;
-
 use crate::config::{Config, MountConfig, NetworkConfig, SecretConfig};
 use crate::image;
 
@@ -33,11 +31,9 @@ pub struct AutoDetected {
 /// Returns `None` if auto-detection can't produce a usable config
 /// (e.g., no known image, no API key).
 pub fn detect() -> Option<AutoDetected> {
-    let home = home_dir();
     detect_with_env(
         std::env::var("ANTHROPIC_API_KEY").ok(),
         image_exists("claude-code"),
-        home.as_deref(),
     )
 }
 
@@ -45,7 +41,6 @@ pub fn detect() -> Option<AutoDetected> {
 fn detect_with_env(
     anthropic_key: Option<String>,
     claude_image_exists: bool,
-    home: Option<&str>,
 ) -> Option<AutoDetected> {
     // For now, we only auto-detect Claude Code setups.
     // Future: detect other agent types (Codex, etc.)
@@ -108,36 +103,12 @@ fn detect_with_env(
         .env
         .insert("CLAUDE_CONFIG_DIR".into(), "/workspace/.claude".into());
 
-    // Git/SSH identity mounts.
-    // NOTE: virtio-fs via libkrun does not currently support read-only mounts,
-    // so these are writable by the guest. The network policy is the primary
-    // security boundary. Users who need stronger isolation should use a
-    // redan.toml with explicit --mount entries.
-    if let Some(home) = home {
-        let gitconfig = Path::new(home).join(".gitconfig");
-        if gitconfig.exists() {
-            config.mount.insert(
-                "gitconfig".into(),
-                MountConfig {
-                    source: gitconfig.to_string_lossy().into_owned(),
-                    target: Some("/home/dev/.gitconfig".into()),
-                },
-            );
-            messages.push("Mounting ~/.gitconfig".into());
-        }
-
-        let ssh_dir = Path::new(home).join(".ssh");
-        if ssh_dir.is_dir() {
-            config.mount.insert(
-                "ssh".into(),
-                MountConfig {
-                    source: ssh_dir.to_string_lossy().into_owned(),
-                    target: Some("/home/dev/.ssh".into()),
-                },
-            );
-            messages.push("Mounting ~/.ssh".into());
-        }
-    }
+    // Neither ~/.gitconfig nor ~/.ssh is mounted by auto-detect.
+    // virtio-fs via libkrun doesn't support read-only mounts, so
+    // both would be writable by the guest. A compromised agent could:
+    //   ~/.ssh: modify authorized_keys, SSH config
+    //   ~/.gitconfig: inject malicious aliases, core.pager, core.hookPath
+    // Users who need these can opt in via redan.toml (see `redan init`).
 
     // Summarize mount
     messages.push("Mounting current directory → /workspace".into());
@@ -152,10 +123,6 @@ fn detect_with_env(
 /// Check if a named image exists.
 fn image_exists(name: &str) -> bool {
     image::image_path(name).map(|p| p.exists()).unwrap_or(false)
-}
-
-fn home_dir() -> Option<String> {
-    std::env::var("HOME").ok()
 }
 
 /// Extract hostnames from git remote URLs in the current directory.
@@ -244,7 +211,7 @@ mod tests {
 
     #[test]
     fn detect_claude_code_with_key_and_image() {
-        let result = detect_with_env(Some("sk-ant-test123".into()), true, Some("/home/testuser"));
+        let result = detect_with_env(Some("sk-ant-test123".into()), true);
         let auto = result.expect("should detect");
         assert_eq!(auto.config.image.as_deref(), Some("claude-code"));
         assert!(auto.config.command.as_deref().unwrap().contains("claude"));
@@ -279,7 +246,7 @@ mod tests {
 
     #[test]
     fn detect_needs_image_build_when_missing() {
-        let result = detect_with_env(Some("sk-ant-test123".into()), false, Some("/home/testuser"));
+        let result = detect_with_env(Some("sk-ant-test123".into()), false);
         let auto = result.expect("should detect");
         assert!(auto.needs_image_build);
         assert!(auto.messages.iter().any(|m| m.contains("will build")));
@@ -287,12 +254,12 @@ mod tests {
 
     #[test]
     fn detect_returns_none_without_api_key() {
-        assert!(detect_with_env(None, true, Some("/home/testuser")).is_none());
+        assert!(detect_with_env(None, true).is_none());
     }
 
     #[test]
     fn detect_returns_none_with_empty_api_key() {
-        assert!(detect_with_env(Some(String::new()), true, Some("/home/testuser")).is_none());
+        assert!(detect_with_env(Some(String::new()), true).is_none());
     }
 
     fn empty_flags() -> ExecFlags<'static> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -791,7 +791,23 @@ fn run_daemon(session_id: &str) {
     let session_dir = session::session_dir(session_id);
     let config_path = session_dir.join("daemon_config.json");
 
-    let config_json = std::fs::read_to_string(&config_path).unwrap_or_else(|e| {
+    // Open the file, then unlink it before reading. The fd keeps the
+    // data accessible but the directory entry is gone, so a crash
+    // between here and process exit can't leave secrets on disk.
+    // Fail closed: if we can't unlink, don't proceed with secrets.
+    let mut config_file = std::fs::File::open(&config_path).unwrap_or_else(|e| {
+        eprintln!("cannot open daemon config: {e}");
+        std::process::exit(1);
+    });
+    if let Err(e) = std::fs::remove_file(&config_path)
+        && e.kind() != std::io::ErrorKind::NotFound
+    {
+        eprintln!("cannot remove daemon config: {e}");
+        std::process::exit(1);
+    }
+
+    let mut config_json = String::new();
+    std::io::Read::read_to_string(&mut config_file, &mut config_json).unwrap_or_else(|e| {
         eprintln!("cannot read daemon config: {e}");
         std::process::exit(1);
     });
@@ -799,9 +815,6 @@ fn run_daemon(session_id: &str) {
         eprintln!("invalid daemon config: {e}");
         std::process::exit(1);
     });
-
-    // Clean up the config file — it contains secret specs
-    let _ = std::fs::remove_file(&config_path);
 
     // Run the VM+proxy (non-interactive: daemon has no terminal)
     cmd::exec::run(&cmd::exec::ExecConfig {

--- a/templates/redan.toml.j2
+++ b/templates/redan.toml.j2
@@ -34,6 +34,19 @@ source = "{{ mount.source }}"
 target = "{{ mount.target }}"
 {%- endif %}
 {%- endfor %}
+
+# Git and SSH identity (not mounted by default).
+# These are writable by the guest because virtio-fs via libkrun
+# doesn't support read-only mounts. Only uncomment if you trust
+# the commands running inside the VM.
+#
+# [mount.gitconfig]
+# source = "~/.gitconfig"
+# target = "/home/dev/.gitconfig"
+#
+# [mount.ssh]
+# source = "~/.ssh"
+# target = "/home/dev/.ssh"
 {%- if env %}
 
 [env]


### PR DESCRIPTION
Three hardening fixes from a security review.

**Stop mounting ~/.ssh and ~/.gitconfig in auto-detect mode**

Auto-detect previously mounted both into the guest VM writable (virtio-fs via libkrun doesn't support read-only). A compromised agent could use either as a persistence vector:

- `~/.ssh`: modify `authorized_keys`, SSH config
- `~/.gitconfig`: inject malicious aliases, `core.pager`, `core.hookPath` that execute on the next host-side `git` invocation

Both are removed from auto-detect. Users opt in via `redan.toml`:

```toml
[mount.gitconfig]
source = "~/.gitconfig"
target = "/home/dev/.gitconfig"

[mount.ssh]
source = "~/.ssh"
target = "/home/dev/.ssh"
```

The `redan init` template now includes these as commented-out examples.

**Unlink daemon config before reading**

When `--detach` is used, secret specs are serialized to `daemon_config.json` (0o600 in a 0o700 directory). Previously, the daemon read the file then deleted it, leaving a small crash window where secrets persist on disk. Now: open, unlink, then read via the fd. The directory entry is gone before we touch the contents.

**Fail closed on unlink failure**

If unlink fails for a reason other than `NotFound` (e.g., weird permissions, read-only fs), the daemon exits rather than proceeding with secrets still on disk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Daemon startup now fails faster with clearer, distinct error messages when config file open/remove/read operations fail.

* **Changes**
  * Auto-detection no longer mounts host identity files by default; mounting is opt-in via configuration.
  * Added commented template entries showing optional Git and SSH mount examples.

* **Documentation**
  * README updated with badges and a new “Why redan?” section; clarified auto-detect behavior and how to enable host mounts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->