### PR TITLE
feat: TCP port forwarding, generic agent registry, read-only mounts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,9 +939,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/ci/libkrun_stub.c
+++ b/ci/libkrun_stub.c
@@ -10,5 +10,6 @@ int krun_set_exec(void) { return 0; }
 int krun_start_enter(void) { return 0; }
 int krun_add_net_unixstream(void) { return 0; }
 int krun_add_virtiofs(void) { return 0; }
+int krun_add_virtiofs3(void) { return 0; }
 int krun_set_console_output(void) { return 0; }
 int krun_set_rlimits(void) { return 0; }

--- a/ci/libkrun_stub.c
+++ b/ci/libkrun_stub.c
@@ -1,15 +1,21 @@
 // Stub for linking against libkrun in CI.
 // Exports the symbols redan's FFI bindings reference. The real
 // libkrun is only needed at runtime.
-int krun_init_log(void) { return 0; }
+//
+// Signatures should match src/ffi.rs declarations (C ABI).
+
+#include <stdbool.h>
+#include <stdint.h>
+
+int krun_init_log(int target_fd, uint32_t level, uint32_t style, uint32_t options) { return 0; }
 int krun_create_ctx(void) { return 0; }
-int krun_set_vm_config(void) { return 0; }
-int krun_set_root(void) { return 0; }
-int krun_set_workdir(void) { return 0; }
-int krun_set_exec(void) { return 0; }
-int krun_start_enter(void) { return 0; }
-int krun_add_net_unixstream(void) { return 0; }
-int krun_add_virtiofs(void) { return 0; }
-int krun_add_virtiofs3(void) { return 0; }
+int krun_set_vm_config(uint32_t ctx_id, uint8_t num_vcpus, uint32_t ram_mib) { return 0; }
+int krun_set_root(uint32_t ctx_id, const char *root_path) { return 0; }
+int krun_set_workdir(uint32_t ctx_id, const char *workdir) { return 0; }
+int krun_set_exec(uint32_t ctx_id, const char *exec_path, const char **argv, const char **envp) { return 0; }
+int krun_start_enter(uint32_t ctx_id) { return 0; }
+int krun_add_net_unixstream(uint32_t ctx_id, const char *c_path, int fd, const uint8_t *c_mac, uint32_t features, uint32_t flags) { return 0; }
+int krun_add_virtiofs(uint32_t ctx_id, const char *c_tag, const char *c_path) { return 0; }
+int krun_add_virtiofs3(uint32_t ctx_id, const char *c_tag, const char *c_path, uint64_t shm_size, bool read_only) { return 0; }
 int krun_set_console_output(void) { return 0; }
-int krun_set_rlimits(void) { return 0; }
+int krun_set_rlimits(uint32_t ctx_id, const char **rlimits) { return 0; }

--- a/src/auto_detect.rs
+++ b/src/auto_detect.rs
@@ -45,11 +45,12 @@ static CLAUDE_CODE: AgentDef = AgentDef {
         home_dir: ".claude",
         credentials_file: ".credentials.json",
         guest_mount: "/redan/host-claude-config",
-        guest_env: &[("CLAUDE_CONFIG_DIR", "/workspace/.claude")],
+        guest_env: &[("CLAUDE_CONFIG_DIR", "/tmp/.claude")],
         extra_hosts: &["auth.anthropic.com", "console.anthropic.com"],
         setup_command: Some(
-            "mkdir -p /workspace/.claude && \
-             cp /redan/host-claude-config/.credentials.json /workspace/.claude/.credentials.json",
+            "mkdir -p /tmp/.claude && \
+             cp /redan/host-claude-config/.credentials.json /tmp/.claude/.credentials.json && \
+             chmod 600 /tmp/.claude/.credentials.json",
         ),
     }),
 };
@@ -456,15 +457,15 @@ mod tests {
         assert_eq!(mount.source, tmp.to_string_lossy());
         assert_eq!(mount.target.as_deref(), Some("/redan/host-claude-config"));
 
-        // CLAUDE_CONFIG_DIR points to writable workspace, not the read-only mount
+        // CLAUDE_CONFIG_DIR points to guest-only tmp dir, not the host workspace
         assert_eq!(
             auto.config.env.get("CLAUDE_CONFIG_DIR").map(String::as_str),
-            Some("/workspace/.claude")
+            Some("/tmp/.claude")
         );
 
-        // Command includes setup to copy credentials before launching
+        // Command copies credentials to guest-only dir before launching
         let cmd = auto.config.command.as_deref().unwrap();
-        assert!(cmd.contains("cp /redan/host-claude-config/.credentials.json"));
+        assert!(cmd.contains("cp /redan/host-claude-config/.credentials.json /tmp/.claude/"));
         assert!(cmd.ends_with("claude --dangerously-skip-permissions"));
 
         assert!(

--- a/src/auto_detect.rs
+++ b/src/auto_detect.rs
@@ -1,182 +1,169 @@
 //! Zero-config auto-detection for `redan exec`.
 //!
-//! When no `redan.toml` exists and no CLI flags are given, redan tries to
-//! detect a usable configuration automatically. Currently detects Claude Code
-//! setups: if the `claude-code` image exists and `ANTHROPIC_API_KEY` is set,
-//! redan runs Claude Code with smart defaults.
+//! When no `redan.toml` exists and no CLI flags are given, redan probes the
+//! environment for known coding agents and builds a sandboxed Config
+//! automatically.
+//!
+//! Each agent is defined as a static `AgentDef` with its auth methods, required
+//! hosts, and runtime settings. Adding support for a new agent means adding a
+//! new entry to `AGENTS`; the detection and config-building logic is generic.
+
+use std::path::{Path, PathBuf};
 
 use crate::config::{Config, MountConfig, NetworkConfig, SecretConfig};
 use crate::image;
 
-/// Hosts required for Claude Code to function.
-const CLAUDE_HOSTS: &[&str] = &[
-    "api.anthropic.com",
-    "statsig.anthropic.com",
-    "sentry.io",
-    "platform.claude.com",
-    "raw.githubusercontent.com",
-];
+// ---------------------------------------------------------------------------
+// Agent registry
+// ---------------------------------------------------------------------------
+
+/// All known agents, ordered by detection priority.
+/// `detect()` returns the first match; `detect_all()` returns every match
+/// (for a future interactive picker).
+static AGENTS: &[&AgentDef] = &[&CLAUDE_CODE];
+
+static CLAUDE_CODE: AgentDef = AgentDef {
+    name: "Claude Code",
+    image: "claude-code",
+    command: "claude --dangerously-skip-permissions",
+    hosts: &[
+        "api.anthropic.com",
+        "statsig.anthropic.com",
+        "sentry.io",
+        "platform.claude.com",
+        "raw.githubusercontent.com",
+    ],
+    interactive: true,
+    timeout_secs: 3600,
+    guest_env: &[],
+    api_key: Some(ApiKeyDef {
+        env_var: "ANTHROPIC_API_KEY",
+        inject_hosts: &["api.anthropic.com"],
+        guest_env: &[("CLAUDE_CONFIG_DIR", "/workspace/.claude")],
+    }),
+    oauth: Some(OAuthDef {
+        home_dir: ".claude",
+        credentials_file: ".credentials.json",
+        guest_mount: "/redan/host-claude-config",
+        guest_env: &[("CLAUDE_CONFIG_DIR", "/workspace/.claude")],
+        extra_hosts: &["auth.anthropic.com", "console.anthropic.com"],
+        setup_command: Some(
+            "mkdir -p /workspace/.claude && \
+             cp /redan/host-claude-config/.credentials.json /workspace/.claude/.credentials.json",
+        ),
+    }),
+};
+
+// ---------------------------------------------------------------------------
+// Agent definition types
+// ---------------------------------------------------------------------------
+
+/// A coding agent that redan can auto-detect and sandbox.
+pub struct AgentDef {
+    pub name: &'static str,
+    pub image: &'static str,
+    pub command: &'static str,
+    /// Network hosts the agent needs to reach.
+    pub hosts: &'static [&'static str],
+    pub interactive: bool,
+    pub timeout_secs: u64,
+    /// Extra guest env vars (set regardless of auth method).
+    pub guest_env: &'static [(&'static str, &'static str)],
+    /// API-key-based auth (tried first).
+    pub api_key: Option<ApiKeyDef>,
+    /// OAuth/stored-credentials auth (fallback when no API key).
+    pub oauth: Option<OAuthDef>,
+}
+
+/// Auth via an environment variable injected as a redan secret.
+pub struct ApiKeyDef {
+    /// Host env var to read (e.g., `ANTHROPIC_API_KEY`).
+    pub env_var: &'static str,
+    /// Hosts the secret is injected into.
+    pub inject_hosts: &'static [&'static str],
+    /// Guest env vars to set when using this auth path.
+    pub guest_env: &'static [(&'static str, &'static str)],
+}
+
+/// Auth via credentials stored in a config directory on the host,
+/// mounted read-only into the guest.
+pub struct OAuthDef {
+    /// Config directory relative to `$HOME` (e.g., `.claude`).
+    pub home_dir: &'static str,
+    /// File that signals credentials exist (e.g., `.credentials.json`).
+    pub credentials_file: &'static str,
+    /// Where to mount the config dir read-only in the guest.
+    pub guest_mount: &'static str,
+    /// Guest env vars to set when using this auth path.
+    pub guest_env: &'static [(&'static str, &'static str)],
+    /// Extra network hosts for token exchange.
+    pub extra_hosts: &'static [&'static str],
+    /// Shell command to run before the agent command, e.g., copying
+    /// credentials from the read-only mount to a writable config dir.
+    pub setup_command: Option<&'static str>,
+}
+
+// ---------------------------------------------------------------------------
+// Detection result types
+// ---------------------------------------------------------------------------
 
 /// Result of auto-detection: a Config plus messages about what was detected.
 pub struct AutoDetected {
     pub config: Config,
     /// Human-readable lines describing what was detected and chosen.
     pub messages: Vec<String>,
-    /// Whether the claude-code image needs to be built first.
+    /// Whether the agent's image needs to be built first.
     pub needs_image_build: bool,
 }
 
-/// Attempt to build a Config from environment detection.
-///
-/// Returns `None` if auto-detection can't produce a usable config
-/// (e.g., no known image, no API key).
+/// A detected agent with its resolved auth method.
+pub struct DetectedAgent {
+    pub agent: &'static AgentDef,
+    pub auth: ResolvedAuth,
+    pub image_exists: bool,
+}
+
+/// The auth method that was actually found in the environment.
+pub enum ResolvedAuth {
+    ApiKey,
+    OAuth { host_config_dir: PathBuf },
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Auto-detect: return a Config for the first detected agent.
 pub fn detect() -> Option<AutoDetected> {
-    detect_with_env(
-        std::env::var("ANTHROPIC_API_KEY").ok(),
-        image_exists("claude-code"),
-    )
+    detect_all().into_iter().next().map(|d| build_config(&d))
 }
 
-/// Testable inner function with injected environment.
-fn detect_with_env(
-    anthropic_key: Option<String>,
-    claude_image_exists: bool,
-) -> Option<AutoDetected> {
-    // For now, we only auto-detect Claude Code setups.
-    // Future: detect other agent types (Codex, etc.)
-    let api_key = anthropic_key?;
-    if api_key.trim().is_empty() {
-        return None;
-    }
-
-    let mut messages = Vec::new();
-    let needs_image_build = !claude_image_exists;
-
-    if claude_image_exists {
-        messages.push("Using image: claude-code".into());
-    } else {
-        messages.push("Image claude-code not found, will build from bundled Dockerfile".into());
-    }
-
-    messages.push("Injecting ANTHROPIC_API_KEY for api.anthropic.com".into());
-
-    let mut config = Config {
-        image: Some("claude-code".into()),
-        command: Some("claude --dangerously-skip-permissions".into()),
-        interactive: Some(true),
-        timeout: Some(3600),
-        ..Config::default()
-    };
-
-    // Network: Claude's required hosts + git remote hosts from the working directory
-    let mut allow: Vec<String> = CLAUDE_HOSTS.iter().map(|&h| h.to_string()).collect();
-    let git_hosts = git_remote_hosts();
-    if !git_hosts.is_empty() {
-        messages.push(format!(
-            "Allowing git remote hosts: {}",
-            git_hosts.join(", ")
-        ));
-        allow.extend(git_hosts);
-    }
-    config.network = NetworkConfig { allow };
-
-    // Secret: ANTHROPIC_API_KEY via env://
-    config.secrets.insert(
-        "ANTHROPIC_API_KEY".into(),
-        SecretConfig {
-            value: "env://ANTHROPIC_API_KEY".to_string(),
-            hosts: vec!["api.anthropic.com".into()],
-        },
-    );
-
-    // Mount: current directory → /workspace
-    config.mount.insert(
-        "workspace".into(),
-        MountConfig {
-            source: ".".into(),
-            target: Some("/workspace".into()),
-        },
-    );
-
-    // Claude Code config dir in workspace
-    config
-        .env
-        .insert("CLAUDE_CONFIG_DIR".into(), "/workspace/.claude".into());
-
-    // Neither ~/.gitconfig nor ~/.ssh is mounted by auto-detect.
-    // virtio-fs via libkrun doesn't support read-only mounts, so
-    // both would be writable by the guest. A compromised agent could:
-    //   ~/.ssh: modify authorized_keys, SSH config
-    //   ~/.gitconfig: inject malicious aliases, core.pager, core.hookPath
-    // Users who need these can opt in via redan.toml (see `redan init`).
-
-    // Summarize mount
-    messages.push("Mounting current directory → /workspace".into());
-
-    Some(AutoDetected {
-        config,
-        messages,
-        needs_image_build,
-    })
-}
-
-/// Check if a named image exists.
-fn image_exists(name: &str) -> bool {
-    image::image_path(name).map(|p| p.exists()).unwrap_or(false)
-}
-
-/// Extract hostnames from git remote URLs in the current directory.
-/// Parses `git remote -v` output; returns empty vec if git isn't available
-/// or we're not in a repo.
-fn git_remote_hosts() -> Vec<String> {
-    let output = std::process::Command::new("git")
-        .args(["remote", "-v"])
-        .stderr(std::process::Stdio::null())
-        .output();
-    let output = match output {
-        Ok(o) if o.status.success() => o,
-        _ => return Vec::new(),
-    };
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let mut hosts: Vec<String> = stdout
-        .lines()
-        .filter_map(|line| {
-            // Lines look like: origin	git@github.com:user/repo.git (fetch)
-            // or: origin	https://github.com/user/repo.git (fetch)
-            let url = line.split_whitespace().nth(1)?;
-            host_from_remote_url(url)
+/// Detect all agents whose auth requirements are satisfied.
+/// Returns them in registry order (highest priority first).
+pub fn detect_all() -> Vec<DetectedAgent> {
+    let home = std::env::var("HOME").ok();
+    AGENTS
+        .iter()
+        .filter_map(|agent| {
+            let api_key_val = agent
+                .api_key
+                .as_ref()
+                .and_then(|a| std::env::var(a.env_var).ok());
+            let oauth_creds = home.as_ref().and_then(|h| {
+                let oauth = agent.oauth.as_ref()?;
+                let path = Path::new(h)
+                    .join(oauth.home_dir)
+                    .join(oauth.credentials_file);
+                path.exists().then_some(path)
+            });
+            probe_with_env(agent, api_key_val.as_deref(), oauth_creds.as_deref(), None)
         })
-        .collect();
-    hosts.sort();
-    hosts.dedup();
-    hosts
+        .collect()
 }
 
-/// Extract hostname from a git remote URL.
-/// Handles HTTPS, HTTP, ssh://, and SCP-style (git@host:path) formats.
-fn host_from_remote_url(url: &str) -> Option<String> {
-    // ssh://[user@]host[:port]/path
-    if let Some(rest) = url.strip_prefix("ssh://") {
-        let authority = rest.rsplit_once('@').map_or(rest, |(_, a)| a);
-        let host = authority.split('/').next()?;
-        return Some(host.split(':').next().unwrap_or(host).to_string());
-    }
-    // https://host[:port]/path or http://
-    if let Some(rest) = url
-        .strip_prefix("https://")
-        .or_else(|| url.strip_prefix("http://"))
-    {
-        return rest
-            .split('/')
-            .next()
-            .map(|h| h.split(':').next().unwrap_or(h).to_string());
-    }
-    // SCP-style: git@github.com:user/repo.git
-    if let Some((_user, host_and_path)) = url.split_once('@') {
-        return host_and_path.split(':').next().map(String::from);
-    }
-    None
-}
+// ---------------------------------------------------------------------------
+// CLI flag detection (unchanged)
+// ---------------------------------------------------------------------------
 
 /// Config-level fields from CLI that indicate the user wants manual control
 /// (not auto-detect). Mode flags like --detach and --name are excluded;
@@ -191,9 +178,6 @@ pub struct ExecFlags<'a> {
     pub discover: bool,
 }
 
-/// Whether the user passed any config-level flags (image, secrets, mounts, etc.).
-/// Mode flags like --detach and --name don't count; they modify how the
-/// session runs, not what it runs.
 pub const fn has_explicit_flags(f: &ExecFlags<'_>) -> bool {
     f.image.is_some()
         || f.rootfs.is_some()
@@ -204,19 +188,223 @@ pub const fn has_explicit_flags(f: &ExecFlags<'_>) -> bool {
         || f.discover
 }
 
+// ---------------------------------------------------------------------------
+// Internal: probing and config building
+// ---------------------------------------------------------------------------
+
+/// Check whether an agent's auth requirements are met.
+/// API key is tried first; OAuth is the fallback.
+fn probe_with_env(
+    agent: &'static AgentDef,
+    api_key_value: Option<&str>,
+    oauth_credentials: Option<&Path>,
+    has_image: Option<bool>,
+) -> Option<DetectedAgent> {
+    let image_exists = has_image.unwrap_or_else(|| image_exists(agent.image));
+
+    if agent.api_key.is_some()
+        && let Some(key) = api_key_value
+        && !key.trim().is_empty()
+    {
+        return Some(DetectedAgent {
+            agent,
+            auth: ResolvedAuth::ApiKey,
+            image_exists,
+        });
+    }
+
+    if agent.oauth.is_some()
+        && let Some(creds_path) = oauth_credentials
+    {
+        let config_dir = creds_path.parent().unwrap_or(creds_path).to_path_buf();
+        return Some(DetectedAgent {
+            agent,
+            auth: ResolvedAuth::OAuth {
+                host_config_dir: config_dir,
+            },
+            image_exists,
+        });
+    }
+
+    None
+}
+
+/// Turn a detected agent into a ready-to-use Config.
+fn build_config(detected: &DetectedAgent) -> AutoDetected {
+    let agent = detected.agent;
+    let mut messages = Vec::new();
+    let needs_image_build = !detected.image_exists;
+
+    if detected.image_exists {
+        messages.push(format!("Using image: {}", agent.image));
+    } else {
+        messages.push(format!(
+            "Image {} not found, will build from bundled Dockerfile",
+            agent.image
+        ));
+    }
+
+    let mut config = Config {
+        image: Some(agent.image.into()),
+        command: Some(agent.command.into()),
+        interactive: Some(agent.interactive),
+        timeout: Some(agent.timeout_secs),
+        ..Config::default()
+    };
+
+    let mut allow: Vec<String> = agent.hosts.iter().map(|&h| h.to_string()).collect();
+
+    for &(key, val) in agent.guest_env {
+        config.env.insert(key.into(), val.into());
+    }
+
+    match &detected.auth {
+        ResolvedAuth::ApiKey => {
+            if let Some(api) = agent.api_key.as_ref() {
+                messages.push(format!(
+                    "Injecting {} for {}",
+                    api.env_var,
+                    api.inject_hosts.join(", ")
+                ));
+                config.secrets.insert(
+                    api.env_var.into(),
+                    SecretConfig {
+                        value: format!("env://{}", api.env_var),
+                        hosts: api.inject_hosts.iter().map(|&h| h.into()).collect(),
+                    },
+                );
+                for &(key, val) in api.guest_env {
+                    config.env.insert(key.into(), val.into());
+                }
+            }
+        }
+        ResolvedAuth::OAuth { host_config_dir } => {
+            if let Some(oauth) = agent.oauth.as_ref() {
+                messages.push(format!(
+                    "Mounting {} → {} (read-only, OAuth credentials)",
+                    host_config_dir.display(),
+                    oauth.guest_mount
+                ));
+                config.mount.insert(
+                    format!("{}-config", agent.image),
+                    MountConfig {
+                        source: host_config_dir.to_string_lossy().into_owned(),
+                        target: Some(oauth.guest_mount.into()),
+                        read_only: true,
+                    },
+                );
+                for &(key, val) in oauth.guest_env {
+                    config.env.insert(key.into(), val.into());
+                }
+                for &host in oauth.extra_hosts {
+                    allow.push(host.to_string());
+                }
+                if let Some(setup) = oauth.setup_command {
+                    config.command = Some(format!("{setup} && {}", agent.command));
+                }
+            }
+        }
+    }
+
+    let git_hosts = git_remote_hosts();
+    if !git_hosts.is_empty() {
+        messages.push(format!(
+            "Allowing git remote hosts: {}",
+            git_hosts.join(", ")
+        ));
+        allow.extend(git_hosts);
+    }
+    config.network = NetworkConfig {
+        allow,
+        ..NetworkConfig::default()
+    };
+
+    config.mount.insert(
+        "workspace".into(),
+        MountConfig {
+            source: ".".into(),
+            target: Some("/workspace".into()),
+            read_only: false,
+        },
+    );
+    messages.push("Mounting current directory → /workspace".into());
+
+    AutoDetected {
+        config,
+        messages,
+        needs_image_build,
+    }
+}
+
+fn image_exists(name: &str) -> bool {
+    image::image_path(name).map(|p| p.exists()).unwrap_or(false)
+}
+
+/// Extract hostnames from git remote URLs in the current directory.
+fn git_remote_hosts() -> Vec<String> {
+    let output = std::process::Command::new("git")
+        .args(["remote", "-v"])
+        .stderr(std::process::Stdio::null())
+        .output();
+    let output = match output {
+        Ok(o) if o.status.success() => o,
+        _ => return Vec::new(),
+    };
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut hosts: Vec<String> = stdout
+        .lines()
+        .filter_map(|line| {
+            let url = line.split_whitespace().nth(1)?;
+            host_from_remote_url(url)
+        })
+        .collect();
+    hosts.sort();
+    hosts.dedup();
+    hosts
+}
+
+/// Extract hostname from a git remote URL.
+/// Handles HTTPS, HTTP, ssh://, and SCP-style (git@host:path) formats.
+fn host_from_remote_url(url: &str) -> Option<String> {
+    if let Some(rest) = url.strip_prefix("ssh://") {
+        let authority = rest.rsplit_once('@').map_or(rest, |(_, a)| a);
+        let host = authority.split('/').next()?;
+        return Some(host.split(':').next().unwrap_or(host).to_string());
+    }
+    if let Some(rest) = url
+        .strip_prefix("https://")
+        .or_else(|| url.strip_prefix("http://"))
+    {
+        return rest
+            .split('/')
+            .next()
+            .map(|h| h.split(':').next().unwrap_or(h).to_string());
+    }
+    if let Some((_user, host_and_path)) = url.split_once('@') {
+        return host_and_path.split(':').next().map(String::from);
+    }
+    None
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 
     #[test]
-    fn detect_claude_code_with_key_and_image() {
-        let result = detect_with_env(Some("sk-ant-test123".into()), true);
-        let auto = result.expect("should detect");
+    fn detect_api_key_produces_correct_config() {
+        let detected = probe_with_env(&CLAUDE_CODE, Some("sk-ant-test123"), None, Some(true))
+            .expect("should detect via API key");
+        assert!(matches!(detected.auth, ResolvedAuth::ApiKey));
+
+        let auto = build_config(&detected);
         assert_eq!(auto.config.image.as_deref(), Some("claude-code"));
         assert!(auto.config.command.as_deref().unwrap().contains("claude"));
         assert_eq!(auto.config.interactive, Some(true));
-        assert!(!auto.needs_image_build);
 
         let secret = auto.config.secrets.get("ANTHROPIC_API_KEY").unwrap();
         assert_eq!(secret.value, "env://ANTHROPIC_API_KEY");
@@ -235,8 +423,12 @@ mod tests {
                 .contains(&"statsig.anthropic.com".to_string())
         );
 
+        assert_eq!(
+            auto.config.env.get("CLAUDE_CONFIG_DIR").map(String::as_str),
+            Some("/workspace/.claude")
+        );
+
         assert!(auto.config.mount.contains_key("workspace"));
-        assert!(auto.messages.iter().any(|m| m.contains("claude-code")));
         assert!(
             auto.messages
                 .iter()
@@ -245,21 +437,96 @@ mod tests {
     }
 
     #[test]
-    fn detect_needs_image_build_when_missing() {
-        let result = detect_with_env(Some("sk-ant-test123".into()), false);
-        let auto = result.expect("should detect");
+    fn detect_oauth_produces_correct_config() {
+        let tmp = std::env::temp_dir().join("redan-test-oauth-refactor");
+        let _ = std::fs::create_dir_all(&tmp);
+        let creds = tmp.join(".credentials.json");
+        std::fs::write(&creds, "{}").unwrap();
+
+        let detected = probe_with_env(&CLAUDE_CODE, None, Some(&creds), Some(true))
+            .expect("should detect via OAuth");
+        assert!(matches!(detected.auth, ResolvedAuth::OAuth { .. }));
+
+        let auto = build_config(&detected);
+        assert_eq!(auto.config.image.as_deref(), Some("claude-code"));
+        assert!(auto.config.secrets.is_empty());
+
+        let mount = auto.config.mount.get("claude-code-config").unwrap();
+        assert!(mount.read_only);
+        assert_eq!(mount.source, tmp.to_string_lossy());
+        assert_eq!(mount.target.as_deref(), Some("/redan/host-claude-config"));
+
+        // CLAUDE_CONFIG_DIR points to writable workspace, not the read-only mount
+        assert_eq!(
+            auto.config.env.get("CLAUDE_CONFIG_DIR").map(String::as_str),
+            Some("/workspace/.claude")
+        );
+
+        // Command includes setup to copy credentials before launching
+        let cmd = auto.config.command.as_deref().unwrap();
+        assert!(cmd.contains("cp /redan/host-claude-config/.credentials.json"));
+        assert!(cmd.ends_with("claude --dangerously-skip-permissions"));
+
+        assert!(
+            auto.config
+                .network
+                .allow
+                .contains(&"auth.anthropic.com".to_string())
+        );
+        assert!(auto.messages.iter().any(|m| m.contains("read-only")));
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn api_key_takes_precedence_over_oauth() {
+        let tmp = std::env::temp_dir().join("redan-test-precedence-refactor");
+        let _ = std::fs::create_dir_all(&tmp);
+        let creds = tmp.join(".credentials.json");
+        std::fs::write(&creds, "{}").unwrap();
+
+        let detected = probe_with_env(&CLAUDE_CODE, Some("sk-ant-test"), Some(&creds), Some(true))
+            .expect("should detect");
+        assert!(matches!(detected.auth, ResolvedAuth::ApiKey));
+
+        let auto = build_config(&detected);
+        assert!(auto.config.secrets.contains_key("ANTHROPIC_API_KEY"));
+        assert!(!auto.config.mount.contains_key("claude-code-config"));
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn no_auth_returns_none() {
+        assert!(probe_with_env(&CLAUDE_CODE, None, None, Some(true)).is_none());
+    }
+
+    #[test]
+    fn empty_api_key_falls_through_to_oauth() {
+        let tmp = std::env::temp_dir().join("redan-test-empty-key");
+        let _ = std::fs::create_dir_all(&tmp);
+        let creds = tmp.join(".credentials.json");
+        std::fs::write(&creds, "{}").unwrap();
+
+        let detected = probe_with_env(&CLAUDE_CODE, Some(""), Some(&creds), Some(true))
+            .expect("should fall through to OAuth");
+        assert!(matches!(detected.auth, ResolvedAuth::OAuth { .. }));
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn empty_api_key_no_oauth_returns_none() {
+        assert!(probe_with_env(&CLAUDE_CODE, Some("  "), None, Some(true)).is_none());
+    }
+
+    #[test]
+    fn needs_image_build_when_image_missing() {
+        let detected = probe_with_env(&CLAUDE_CODE, Some("sk-ant-test"), None, Some(false))
+            .expect("should detect");
+        let auto = build_config(&detected);
         assert!(auto.needs_image_build);
         assert!(auto.messages.iter().any(|m| m.contains("will build")));
-    }
-
-    #[test]
-    fn detect_returns_none_without_api_key() {
-        assert!(detect_with_env(None, true).is_none());
-    }
-
-    #[test]
-    fn detect_returns_none_with_empty_api_key() {
-        assert!(detect_with_env(Some(String::new()), true).is_none());
     }
 
     fn empty_flags() -> ExecFlags<'static> {

--- a/src/cmd/exec.rs
+++ b/src/cmd/exec.rs
@@ -16,6 +16,7 @@ pub(crate) struct ExecConfig<'a> {
     pub timeout_secs: u64,
     pub secret_specs: &'a [String],
     pub allow_host_specs: &'a [String],
+    pub forward_specs: &'a [String],
     pub mount_specs: &'a [String],
     pub audit_log_path: Option<&'a str>,
     pub image_name: Option<&'a str>,
@@ -141,22 +142,24 @@ pub(crate) fn run(cfg: &ExecConfig<'_>) {
     };
 
     // Parse mounts
-    let mut virtiofs_mounts: Vec<(String, String)> = Vec::new();
+    let mut virtiofs_mounts: Vec<(String, String, bool)> = Vec::new();
     let mut mount_commands: Vec<String> = Vec::new();
     for (i, spec) in cfg.mount_specs.iter().enumerate() {
-        let (host_path, guest_path) = parse_mount(spec);
+        let (host_path, guest_path, read_only) = parse_mount(spec);
         if !Path::new(&host_path).exists() {
             eprintln!("mount source does not exist: {host_path}");
             std::process::exit(1);
         }
         let tag = format!("fs{i}");
-        log::info!("mount: {host_path} -> {guest_path} (tag={tag})");
+        let ro_label = if read_only { " (ro)" } else { "" };
+        log::info!("mount: {host_path} -> {guest_path}{ro_label} (tag={tag})");
 
         let mp = Path::new(cfg.rootfs).join(guest_path.trim_start_matches('/'));
         std::fs::create_dir_all(&mp).ok();
 
-        virtiofs_mounts.push((tag.clone(), host_path));
-        mount_commands.push(format!("mount -t virtiofs {tag} {guest_path}"));
+        virtiofs_mounts.push((tag.clone(), host_path, read_only));
+        let mount_opts = if read_only { " -o ro" } else { "" };
+        mount_commands.push(format!("mount -t virtiofs{mount_opts} {tag} {guest_path}"));
     }
 
     // Build guest command: network setup + CA trust + mounts + user command
@@ -238,6 +241,28 @@ pub(crate) fn run(cfg: &ExecConfig<'_>) {
         }
     };
 
+    let mut forwards: Vec<proxy::ForwardSpec> = Vec::new();
+    for spec in cfg.forward_specs {
+        match proxy::parse_forward_spec(spec) {
+            Ok(fwd) => {
+                if forwards.iter().any(|f| f.guest_port == fwd.guest_port) {
+                    eprintln!("duplicate forward guest port: {}", fwd.guest_port);
+                    std::process::exit(1);
+                }
+                log::info!(
+                    "forward: :{} -> 127.0.0.1:{}",
+                    fwd.guest_port,
+                    fwd.host_port
+                );
+                forwards.push(fwd);
+            }
+            Err(e) => {
+                eprintln!("invalid --forward spec '{spec}': {e}");
+                std::process::exit(1);
+            }
+        }
+    }
+
     let discovered = proxy::run(proxy::ProxyConfig {
         host_sock: net_sock,
         ca: std::sync::Arc::new(std::sync::Mutex::new(ca)),
@@ -246,6 +271,7 @@ pub(crate) fn run(cfg: &ExecConfig<'_>) {
         allowed_hosts,
         audit_log_path,
         discover: cfg.discover,
+        forwards: &forwards,
     });
 
     if cfg.discover && !discovered.is_empty() {
@@ -367,11 +393,15 @@ pub(crate) fn collect_secret_specs(
 }
 
 /// Parse mount spec: `/host/path:/guest/path` or `/host/path` (defaults to `/workspace`)
-pub(crate) fn parse_mount(spec: &str) -> (String, String) {
-    spec.split_once(':').map_or_else(
-        || (spec.to_string(), "/workspace".to_string()),
-        |(host, guest)| (host.to_string(), guest.to_string()),
-    )
+/// Parse a mount spec: `host_path[:guest_path[:ro]]`.
+/// Returns `(host_path, guest_path, read_only)`.
+pub(crate) fn parse_mount(spec: &str) -> (String, String, bool) {
+    let parts: Vec<&str> = spec.splitn(3, ':').collect();
+    match parts.as_slice() {
+        [host, guest, "ro"] => (host.to_string(), guest.to_string(), true),
+        [host, guest] => (host.to_string(), guest.to_string(), false),
+        _ => (spec.to_string(), "/workspace".to_string(), false),
+    }
 }
 
 fn write_guest_policy(rootfs: &Path, allowed_hosts: Option<&Vec<String>>) {
@@ -453,16 +483,26 @@ mod tests {
 
     #[test]
     fn parse_mount_with_guest_path() {
-        let (host, guest) = parse_mount("/home/chris/project:/workspace");
+        let (host, guest, ro) = parse_mount("/home/chris/project:/workspace");
         assert_eq!(host, "/home/chris/project");
         assert_eq!(guest, "/workspace");
+        assert!(!ro);
     }
 
     #[test]
     fn parse_mount_default_guest_path() {
-        let (host, guest) = parse_mount("/home/chris/project");
+        let (host, guest, ro) = parse_mount("/home/chris/project");
         assert_eq!(host, "/home/chris/project");
         assert_eq!(guest, "/workspace");
+        assert!(!ro);
+    }
+
+    #[test]
+    fn parse_mount_read_only() {
+        let (host, guest, ro) = parse_mount("/home/chris/.claude:/claude-config:ro");
+        assert_eq!(host, "/home/chris/.claude");
+        assert_eq!(guest, "/claude-config");
+        assert!(ro);
     }
 
     #[test]

--- a/src/cmd/exec.rs
+++ b/src/cmd/exec.rs
@@ -392,15 +392,18 @@ pub(crate) fn collect_secret_specs(
     specs
 }
 
-/// Parse mount spec: `/host/path:/guest/path` or `/host/path` (defaults to `/workspace`)
-/// Parse a mount spec: `host_path[:guest_path[:ro]]`.
+/// Parse a mount spec: `host[:guest[:ro]]`.
 /// Returns `(host_path, guest_path, read_only)`.
 pub(crate) fn parse_mount(spec: &str) -> (String, String, bool) {
-    let parts: Vec<&str> = spec.splitn(3, ':').collect();
-    match parts.as_slice() {
-        [host, guest, "ro"] => (host.to_string(), guest.to_string(), true),
-        [host, guest] => (host.to_string(), guest.to_string(), false),
-        _ => (spec.to_string(), "/workspace".to_string(), false),
+    let (base, read_only) = spec
+        .strip_suffix(":ro")
+        .map_or((spec, false), |s| (s, true));
+
+    match base.split_once(':') {
+        Some((host, guest)) if !guest.is_empty() => {
+            (host.to_string(), guest.to_string(), read_only)
+        }
+        _ => (base.to_string(), "/workspace".to_string(), read_only),
     }
 }
 
@@ -502,6 +505,14 @@ mod tests {
         let (host, guest, ro) = parse_mount("/home/chris/.claude:/claude-config:ro");
         assert_eq!(host, "/home/chris/.claude");
         assert_eq!(guest, "/claude-config");
+        assert!(ro);
+    }
+
+    #[test]
+    fn parse_mount_read_only_no_guest_path() {
+        let (host, guest, ro) = parse_mount("/home/chris/.claude:ro");
+        assert_eq!(host, "/home/chris/.claude");
+        assert_eq!(guest, "/workspace");
         assert!(ro);
     }
 

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -81,6 +81,7 @@ pub(crate) fn run(claude: bool) {
         config::MountConfig {
             source: ".".into(),
             target: Some("/workspace".into()),
+            read_only: false,
         },
     );
 
@@ -249,6 +250,45 @@ pub(crate) fn detect_project() -> Vec<ProjectDetection> {
             "PHP (composer.json)",
             &["repo.packagist.org"],
             &["php", "composer"],
+        ),
+        (
+            "pubspec.yaml",
+            "Flutter/Dart (pubspec.yaml)",
+            &["pub.dev", "storage.googleapis.com"],
+            &[],
+        ),
+        (
+            "pom.xml",
+            "Java (pom.xml)",
+            &["repo1.maven.org"],
+            &["openjdk21-jdk", "maven"],
+        ),
+        (
+            "build.gradle",
+            "Java/Kotlin (build.gradle)",
+            &[
+                "services.gradle.org",
+                "plugins.gradle.org",
+                "repo1.maven.org",
+            ],
+            &["openjdk21-jdk"],
+        ),
+        (
+            "build.gradle.kts",
+            "Kotlin (build.gradle.kts)",
+            &[
+                "services.gradle.org",
+                "plugins.gradle.org",
+                "repo1.maven.org",
+            ],
+            &["openjdk21-jdk"],
+        ),
+        ("Package.swift", "Swift (Package.swift)", &[], &[]),
+        (
+            "mix.exs",
+            "Elixir (mix.exs)",
+            &["hex.pm", "repo.hex.pm"],
+            &["elixir"],
         ),
     ];
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -52,6 +52,9 @@ pub struct Config {
 pub struct NetworkConfig {
     #[serde(default)]
     pub allow: Vec<String>,
+    /// TCP port forwards: `"9222"` or `"9222:3000"` (`guest_port:host_port`).
+    #[serde(default)]
+    pub forward: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -64,6 +67,8 @@ pub struct SecretConfig {
 pub struct MountConfig {
     pub source: String,
     pub target: Option<String>,
+    #[serde(default)]
+    pub read_only: bool,
 }
 
 impl Config {
@@ -82,9 +87,15 @@ impl Config {
         self.mount
             .values()
             .map(|m| {
-                m.target
+                let base = m
+                    .target
                     .as_ref()
-                    .map_or_else(|| m.source.clone(), |t| format!("{}:{t}", m.source))
+                    .map_or_else(|| m.source.clone(), |t| format!("{}:{t}", m.source));
+                if m.read_only {
+                    format!("{base}:ro")
+                } else {
+                    base
+                }
             })
             .collect()
     }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -30,5 +30,12 @@ unsafe extern "C" {
         flags: u32,
     ) -> i32;
     pub fn krun_add_virtiofs(ctx_id: u32, c_tag: *const c_char, c_path: *const c_char) -> i32;
+    pub fn krun_add_virtiofs3(
+        ctx_id: u32,
+        c_tag: *const c_char,
+        c_path: *const c_char,
+        shm_size: u64,
+        read_only: bool,
+    ) -> i32;
     pub fn krun_set_rlimits(ctx_id: u32, rlimits: *const *const c_char) -> i32;
 }

--- a/src/image.rs
+++ b/src/image.rs
@@ -195,9 +195,11 @@ fn build_image(dest: &Path, packages: &[String], run_commands: &[String]) -> io:
         let pkg_list = packages.join(" ");
         // apk exits non-zero on chown failures (guest UID != root on host).
         // The packages install fine, just with host-user ownership.
-        // Use || true so subsequent --run commands still execute.
+        // Filter the "Failed to set ownership" stderr noise so the
+        // terminal stays readable, and || true so subsequent commands
+        // still execute regardless of apk's exit code.
         setup_parts.push(format!(
-            "apk update && (apk add --no-cache {pkg_list} || true)"
+            "apk update && (apk add --no-cache {pkg_list} 2>&1 | grep -v 'Failed to set ownership' || true)"
         ));
     }
 
@@ -245,6 +247,7 @@ fn build_image(dest: &Path, packages: &[String], run_commands: &[String]) -> io:
         allowed_hosts: None,               // unrestricted during build
         audit_log_path: None,
         discover: false,
+        forwards: &[],
     });
 
     // Verify the build completed successfully by checking for the

--- a/src/main.rs
+++ b/src/main.rs
@@ -132,6 +132,13 @@ enum Cli {
         #[arg(long = "allow-host", value_name = "HOST")]
         allow_hosts: Vec<String>,
 
+        /// Forward a guest TCP port to host localhost.
+        /// Format: PORT (same port both sides) or `GUEST_PORT:HOST_PORT`.
+        /// The guest connects to the gateway IP on `GUEST_PORT`; redan
+        /// relays to `127.0.0.1:HOST_PORT`.
+        #[arg(long = "forward", value_name = "SPEC")]
+        forwards: Vec<String>,
+
         /// Mount a host directory into the guest via virtio-fs.
         /// Format: /host/path:/guest/path (default guest path: /workspace)
         #[arg(long = "mount", short = 'm', value_name = "HOST:GUEST")]
@@ -285,6 +292,7 @@ fn main() {
             secrets,
             secret_file,
             allow_hosts,
+            forwards,
             mounts,
             audit_log,
             log_file: _,
@@ -303,6 +311,7 @@ fn main() {
                 allow_hosts,
                 mounts,
                 audit_log,
+                forwards,
                 discover,
                 detach,
                 name,
@@ -479,6 +488,7 @@ struct ExecArgs {
     allow_hosts: Vec<String>,
     mounts: Vec<String>,
     audit_log: Option<String>,
+    forwards: Vec<String>,
     discover: bool,
     detach: bool,
     name: Option<String>,
@@ -526,11 +536,10 @@ fn exec_command(args: ExecArgs) {
         } else {
             eprintln!("no redan.toml found and auto-detect failed.");
             eprintln!();
-            if std::env::var("ANTHROPIC_API_KEY").is_err() {
-                eprintln!("  Set ANTHROPIC_API_KEY to auto-detect Claude Code:");
-                eprintln!("    export ANTHROPIC_API_KEY=sk-ant-...");
-                eprintln!();
-            }
+            eprintln!("  Auto-detect needs one of:");
+            eprintln!("    export ANTHROPIC_API_KEY=sk-ant-...    (API key)");
+            eprintln!("    claude login                           (OAuth/Pro/Max/Team)");
+            eprintln!();
             eprintln!("  Or create a config:");
             eprintln!("    redan init          generate a redan.toml");
             eprintln!("    redan init --claude  generate config + devcontainer for Claude Code");
@@ -572,6 +581,9 @@ fn exec_command(args: ExecArgs) {
         );
         allow_hosts.extend(claude_domains);
     }
+
+    let mut forwards = args.forwards;
+    forwards.extend(cfg.network.forward.clone());
 
     let mut mounts = args.mounts;
     mounts.extend(cfg.mount_specs());
@@ -622,6 +634,7 @@ fn exec_command(args: ExecArgs) {
             timeout,
             &secrets,
             &allow_hosts,
+            &forwards,
             &mounts,
             audit_log.as_deref(),
             image_name.as_deref(),
@@ -637,6 +650,7 @@ fn exec_command(args: ExecArgs) {
             timeout_secs: timeout,
             secret_specs: &secrets,
             allow_host_specs: &allow_hosts,
+            forward_specs: &forwards,
             mount_specs: &mounts,
             audit_log_path: audit_log.as_deref(),
             image_name: image_name.as_deref(),
@@ -656,6 +670,7 @@ struct DaemonConfig {
     timeout_secs: u64,
     secrets: Vec<String>,
     allow_hosts: Vec<String>,
+    forwards: Vec<String>,
     mounts: Vec<String>,
     audit_log: Option<String>,
     image_name: Option<String>,
@@ -671,6 +686,7 @@ fn exec_detached(
     timeout: u64,
     secrets: &[String],
     allow_hosts: &[String],
+    forwards: &[String],
     mounts: &[String],
     audit_log: Option<&str>,
     image_name: Option<&str>,
@@ -700,6 +716,7 @@ fn exec_detached(
         timeout_secs: timeout,
         secrets: secrets.to_vec(),
         allow_hosts: allow_hosts.to_vec(),
+        forwards: forwards.to_vec(),
         mounts: mounts.to_vec(),
         audit_log: audit_log.map(Into::into),
         image_name: image_name.map(Into::into),
@@ -824,6 +841,7 @@ fn run_daemon(session_id: &str) {
         timeout_secs: cfg.timeout_secs,
         secret_specs: &cfg.secrets,
         allow_host_specs: &cfg.allow_hosts,
+        forward_specs: &cfg.forwards,
         mount_specs: &cfg.mounts,
         audit_log_path: cfg.audit_log.as_deref(),
         image_name: cfg.image_name.as_deref(),

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -36,6 +36,57 @@ pub const GATEWAY_IP: Ipv4Address = Ipv4Address::new(192, 168, 127, 1);
 pub const GATEWAY_MAC: EthernetAddress = EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x02]);
 pub const GUEST_IP: &str = "192.168.127.2";
 
+// --- TCP port forwarding ---
+
+/// Ports reserved by the proxy for internal services.
+const RESERVED_PORTS: &[u16] = &[22, 53, 80, 443];
+
+/// A TCP port forwarding specification.
+///
+/// Guest connects to `gateway:guest_port`, redan relays to
+/// `127.0.0.1:host_port` on the host. Target is always localhost;
+/// the guest cannot influence the destination.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ForwardSpec {
+    pub guest_port: u16,
+    pub host_port: u16,
+}
+
+/// Parse a forward spec string.
+///
+/// Accepted formats:
+/// - `"9222"` -- same port on both sides
+/// - `"9222:3000"` -- `guest_port:host_port`
+///
+/// Rejects reserved ports (22, 53, 80, 443) and port 0.
+pub fn parse_forward_spec(spec: &str) -> Result<ForwardSpec, String> {
+    let (guest_str, host_str) = spec.split_once(':').map_or((spec, spec), |(g, h)| (g, h));
+
+    let guest_port: u16 = guest_str
+        .parse()
+        .map_err(|_| format!("invalid guest port: {guest_str}"))?;
+    let host_port: u16 = host_str
+        .parse()
+        .map_err(|_| format!("invalid host port: {host_str}"))?;
+
+    if guest_port == 0 {
+        return Err("guest port cannot be 0".into());
+    }
+    if host_port == 0 {
+        return Err("host port cannot be 0".into());
+    }
+    if RESERVED_PORTS.contains(&guest_port) {
+        return Err(format!(
+            "guest port {guest_port} is reserved (used by redan internally)"
+        ));
+    }
+
+    Ok(ForwardSpec {
+        guest_port,
+        host_port,
+    })
+}
+
 /// IP assigned to DNS queries for "localhost".
 #[allow(clippy::ip_constant)] // smoltcp type, not std
 const LOOPBACK_IP: Ipv4Address = Ipv4Address::new(127, 0, 0, 1);
@@ -148,6 +199,9 @@ pub struct ProxyConfig<'a> {
     pub audit_log_path: Option<&'a str>,
     /// Discover mode: allow all connections, collect hostnames.
     pub discover: bool,
+    /// TCP port forwards: guest connects to `gateway:guest_port`,
+    /// redan relays to `127.0.0.1:host_port`.
+    pub forwards: &'a [ForwardSpec],
 }
 
 /// Hosts observed during a discover-mode run.
@@ -164,6 +218,7 @@ pub fn run(cfg: ProxyConfig<'_>) -> Vec<String> {
         allowed_hosts,
         audit_log_path,
         discover,
+        forwards,
     } = cfg;
     let resolver = Arc::new(MitmCertResolver {
         ca: Arc::clone(&ca),
@@ -228,6 +283,23 @@ pub fn run(cfg: ProxyConfig<'_>) -> Vec<String> {
         },
     ];
 
+    for fwd in forwards {
+        backlogs.push(ListenBacklog {
+            port: fwd.guest_port,
+            kind: BacklogKind::TcpForward {
+                host_port: fwd.host_port,
+            },
+            handles: (0..LISTEN_BACKLOG)
+                .map(|_| add_tcp_listener(&mut sockets, fwd.guest_port))
+                .collect(),
+        });
+        log::info!(
+            "TCP forward: :{} -> 127.0.0.1:{}",
+            fwd.guest_port,
+            fwd.host_port,
+        );
+    }
+
     log::info!("proxy listening on :22 (ssh), :53 (dns), :80, :443");
     let start = Instant::now();
 
@@ -282,6 +354,9 @@ pub fn run(cfg: ProxyConfig<'_>) -> Vec<String> {
                         let conn_kind = match backlog.kind {
                             BacklogKind::Http => ConnKind::Http,
                             BacklogKind::Tls => ConnKind::TlsMitm,
+                            BacklogKind::TcpForward { host_port } => {
+                                ConnKind::TcpForward { host_port }
+                            }
                             BacklogKind::Ssh => {
                                 let dest_ip = sock.local_endpoint().and_then(|ep| {
                                     if let smoltcp::wire::IpAddress::Ipv4(ip) = ep.addr {
@@ -383,6 +458,8 @@ enum BacklogKind {
     Tls,
     /// TCP/22: transparent relay, no inspection.
     Ssh,
+    /// Forwarded port: transparent relay to host localhost.
+    TcpForward { host_port: u16 },
 }
 
 struct ListenBacklog {
@@ -471,6 +548,8 @@ enum ConnKind {
         /// thread for the private-IP check (same logic as TLS path).
         allow_private: bool,
     },
+    /// Forwarded port: transparent relay to `127.0.0.1:host_port`.
+    TcpForward { host_port: u16 },
 }
 
 struct ProxyConn {
@@ -550,6 +629,20 @@ impl ProxyConn {
                         &disc,
                     ) {
                         log::warn!("TLS connection thread error: {e}");
+                    }
+                });
+            }
+            ConnKind::TcpForward { host_port } => {
+                let (to_tx, to_rx) = mpsc::channel::<Vec<u8>>();
+                let (from_tx, from_rx) = mpsc::sync_channel::<Vec<u8>>(64);
+                conn.to_thread = Some(to_tx);
+                conn.from_thread = Some(from_rx);
+                conn.state = ConnState::Shuttling;
+
+                let alog = audit_log.clone();
+                std::thread::spawn(move || {
+                    if let Err(e) = tcp_forward_thread(to_rx, from_tx, host_port, &alog) {
+                        log::warn!("TCP forward thread error for port {host_port}: {e}");
                     }
                 });
             }
@@ -1229,6 +1322,80 @@ fn ssh_relay_thread(
     Ok(())
 }
 
+/// Transparent TCP relay for port-forwarded connections.
+///
+/// Forwards raw bytes between the guest (via smoltcp channels) and
+/// `127.0.0.1:host_port` on the host. No inspection, no injection,
+/// no scrubbing. Target is always localhost; the guest cannot
+/// influence the destination.
+#[allow(dead_code)] // wired up once TcpForward match arms are implemented
+fn tcp_forward_thread(
+    rx: mpsc::Receiver<Vec<u8>>,
+    tx: mpsc::SyncSender<Vec<u8>>,
+    host_port: u16,
+    audit_log: &AuditLog,
+) -> Result<(), crate::error::Error> {
+    use std::net::{Shutdown, SocketAddr, TcpStream};
+
+    let addr = SocketAddr::from(([127, 0, 0, 1], host_port));
+    let upstream = TcpStream::connect_timeout(&addr, Duration::from_secs(5))
+        .map_err(|e| format!("TCP forward connect to 127.0.0.1:{host_port}: {e}"))?;
+    upstream.set_read_timeout(Some(Duration::from_secs(30)))?;
+    upstream.set_write_timeout(Some(Duration::from_secs(30)))?;
+
+    audit(
+        audit_log,
+        "forward_connect",
+        &[("host_port", &host_port.to_string())],
+    );
+    log::info!("TCP forward: connected to 127.0.0.1:{host_port}");
+
+    let mut upstream_r = upstream
+        .try_clone()
+        .map_err(|e| format!("TCP forward stream clone: {e}"))?;
+    let mut upstream_w = upstream;
+
+    // Upstream -> guest
+    let port_copy = host_port;
+    let read_thread = std::thread::spawn(move || {
+        let mut buf = vec![0u8; 16384];
+        loop {
+            match upstream_r.read(&mut buf) {
+                Ok(0) => break,
+                Ok(n) => {
+                    if tx.send(buf[..n].to_vec()).is_err() {
+                        break;
+                    }
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::ConnectionReset => break,
+                Err(e) => {
+                    log::debug!("TCP forward upstream read error for port {port_copy}: {e}");
+                    break;
+                }
+            }
+        }
+    });
+
+    // Guest -> upstream
+    for data in rx {
+        if upstream_w.write_all(&data).is_err() {
+            break;
+        }
+    }
+
+    upstream_w.shutdown(Shutdown::Write).ok();
+    read_thread.join().ok();
+
+    audit(
+        audit_log,
+        "forward_disconnect",
+        &[("host_port", &host_port.to_string())],
+    );
+    log::info!("TCP forward: disconnected from 127.0.0.1:{host_port}");
+
+    Ok(())
+}
+
 /// Write a body chunk with secret scrubbing. Maintains an overlap
 /// buffer to catch secrets spanning chunk boundaries.
 fn write_scrubbed_chunk(
@@ -1369,7 +1536,7 @@ fn request_has_upgrade(data: &[u8]) -> bool {
 /// - `"api.example.com"` matches `"api.example.com"` and `"API.EXAMPLE.COM"`
 /// - `"*.example.com"` matches `"api.example.com"` and `"foo.bar.example.com"`
 /// - `"*.example.com"` does NOT match `"example.com"` (must have a subdomain)
-pub(crate) fn host_matches(pattern: &str, hostname: &str) -> bool {
+pub fn host_matches(pattern: &str, hostname: &str) -> bool {
     pattern.strip_prefix("*.").map_or_else(
         || pattern.eq_ignore_ascii_case(hostname),
         |suffix| {
@@ -1587,6 +1754,73 @@ mod tests {
     fn chunked_te_absent() {
         let req = b"POST /api HTTP/1.1\r\nContent-Length: 5\r\n\r\nhello";
         assert!(!request_has_chunked_te(req));
+    }
+
+    // --- ForwardSpec parsing ---
+
+    #[test]
+    fn parse_forward_spec_single_port() {
+        let spec = parse_forward_spec("9222").unwrap();
+        assert_eq!(
+            spec,
+            ForwardSpec {
+                guest_port: 9222,
+                host_port: 9222
+            }
+        );
+    }
+
+    #[test]
+    fn parse_forward_spec_guest_host_pair() {
+        let spec = parse_forward_spec("8080:3000").unwrap();
+        assert_eq!(
+            spec,
+            ForwardSpec {
+                guest_port: 8080,
+                host_port: 3000
+            }
+        );
+    }
+
+    #[test]
+    fn parse_forward_spec_rejects_reserved_port_22() {
+        assert!(parse_forward_spec("22").is_err());
+    }
+
+    #[test]
+    fn parse_forward_spec_rejects_reserved_port_53() {
+        assert!(parse_forward_spec("53").is_err());
+    }
+
+    #[test]
+    fn parse_forward_spec_rejects_reserved_port_80() {
+        assert!(parse_forward_spec("80:8080").is_err());
+    }
+
+    #[test]
+    fn parse_forward_spec_rejects_reserved_port_443() {
+        assert!(parse_forward_spec("443").is_err());
+    }
+
+    #[test]
+    fn parse_forward_spec_rejects_zero_guest() {
+        assert!(parse_forward_spec("0:8080").is_err());
+    }
+
+    #[test]
+    fn parse_forward_spec_rejects_zero_host() {
+        assert!(parse_forward_spec("8080:0").is_err());
+    }
+
+    #[test]
+    fn parse_forward_spec_rejects_non_numeric() {
+        assert!(parse_forward_spec("abc").is_err());
+        assert!(parse_forward_spec("9222:abc").is_err());
+    }
+
+    #[test]
+    fn parse_forward_spec_rejects_overflow() {
+        assert!(parse_forward_spec("99999").is_err());
     }
 
     // --- write_scrubbed_chunk overlap tests ---

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -81,6 +81,13 @@ pub fn parse_forward_spec(spec: &str) -> Result<ForwardSpec, String> {
         ));
     }
 
+    if host_port < 1024 {
+        log::warn!(
+            "forwarding to privileged host port {host_port}; \
+             make sure this is intentional"
+        );
+    }
+
     Ok(ForwardSpec {
         guest_port,
         host_port,
@@ -1328,7 +1335,6 @@ fn ssh_relay_thread(
 /// `127.0.0.1:host_port` on the host. No inspection, no injection,
 /// no scrubbing. Target is always localhost; the guest cannot
 /// influence the destination.
-#[allow(dead_code)] // wired up once TcpForward match arms are implemented
 fn tcp_forward_thread(
     rx: mpsc::Receiver<Vec<u8>>,
     tx: mpsc::SyncSender<Vec<u8>>,
@@ -1340,8 +1346,6 @@ fn tcp_forward_thread(
     let addr = SocketAddr::from(([127, 0, 0, 1], host_port));
     let upstream = TcpStream::connect_timeout(&addr, Duration::from_secs(5))
         .map_err(|e| format!("TCP forward connect to 127.0.0.1:{host_port}: {e}"))?;
-    upstream.set_read_timeout(Some(Duration::from_secs(30)))?;
-    upstream.set_write_timeout(Some(Duration::from_secs(30)))?;
 
     audit(
         audit_log,

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -107,6 +107,7 @@ mod tests {
             interactive: Some(true),
             network: NetworkConfig {
                 allow: vec!["api.anthropic.com".into(), "pypi.org".into()],
+                ..NetworkConfig::default()
             },
             ..Config::default()
         };
@@ -115,6 +116,7 @@ mod tests {
             MountConfig {
                 source: ".".into(),
                 target: Some("/workspace".into()),
+                read_only: false,
             },
         );
         cfg.env
@@ -135,6 +137,7 @@ mod tests {
             command: Some("/bin/sh".into()),
             network: NetworkConfig {
                 allow: vec!["registry.npmjs.org".into()],
+                ..NetworkConfig::default()
             },
             ..Config::default()
         };
@@ -143,6 +146,7 @@ mod tests {
             MountConfig {
                 source: ".".into(),
                 target: Some("/workspace".into()),
+                read_only: false,
             },
         );
 

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -47,6 +47,7 @@ pub fn redan_toml(cfg: &Config, claude: bool) -> String {
             timeout => cfg.timeout,
             claude,
             allow_hosts => cfg.network.allow,
+            forwards => cfg.network.forward,
             mounts,
             env => env_vars,
         })
@@ -155,6 +156,24 @@ mod tests {
         assert!(out.contains("# Allowed outbound hosts"));
         assert!(!out.contains("dangerously"));
         assert!(!out.contains("CLAUDE_CONFIG_DIR"));
+    }
+
+    #[test]
+    fn redan_toml_with_forwards() {
+        let cfg = Config {
+            image: Some("myapp".into()),
+            command: Some("/bin/sh".into()),
+            network: NetworkConfig {
+                allow: vec![],
+                forward: vec!["9222".into(), "8080:3000".into()],
+            },
+            ..Config::default()
+        };
+
+        let out = redan_toml(&cfg, false);
+        assert!(out.contains("\"9222\""));
+        assert!(out.contains("\"8080:3000\""));
+        assert!(out.contains("forward = ["));
     }
 
     #[test]

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -40,8 +40,8 @@ pub struct VmConfig {
     pub command: String,
     /// Environment variables for the guest process.
     pub env: Vec<String>,
-    /// Host directories to mount via virtio-fs: `(tag, host_path)`.
-    pub virtiofs_mounts: Vec<(String, String)>,
+    /// Host directories to mount via virtio-fs: `(tag, host_path, read_only)`.
+    pub virtiofs_mounts: Vec<(String, String, bool)>,
     /// Interactive mode: attach host terminal to guest console.
     /// When true, stdin/stdout/stderr are passed to the VM via
     /// virtio-console so the user gets an interactive shell.
@@ -143,11 +143,13 @@ impl Vm {
         krun_check!(ret >= 0, "krun_add_net_unixstream failed: {ret}");
 
         // virtio-fs mounts
-        for (tag, path) in &config.virtiofs_mounts {
+        for (tag, path, read_only) in &config.virtiofs_mounts {
             let c_tag = CString::new(tag.as_str()).unwrap();
             let c_path = CString::new(path.as_str()).unwrap();
-            let ret = unsafe { ffi::krun_add_virtiofs(ctx_id, c_tag.as_ptr(), c_path.as_ptr()) };
-            krun_check!(ret >= 0, "krun_add_virtiofs({tag}, {path}) failed: {ret}");
+            let ret = unsafe {
+                ffi::krun_add_virtiofs3(ctx_id, c_tag.as_ptr(), c_path.as_ptr(), 0, *read_only)
+            };
+            krun_check!(ret >= 0, "krun_add_virtiofs3({tag}, {path}) failed: {ret}");
         }
 
         // The implicit console uses the host process's stdio.

--- a/templates/redan.toml.j2
+++ b/templates/redan.toml.j2
@@ -26,6 +26,15 @@ allow = [
     "{{ host }}",
 {%- endfor %}
 ]
+{%- if forwards %}
+# TCP port forwards (guest -> host localhost).
+# Format: "PORT" or "GUEST_PORT:HOST_PORT"
+forward = [
+{%- for fwd in forwards %}
+    "{{ fwd }}",
+{%- endfor %}
+]
+{%- endif %}
 {%- for tag, mount in mounts %}
 
 [mount.{{ tag }}]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -94,6 +94,7 @@ fn end_to_end_secret_injection() {
         allowed_hosts: None,
         audit_log_path: None,
         discover: false,
+        forwards: &[],
     });
 }
 
@@ -146,5 +147,6 @@ fn synthetic_dns_resolution() {
         allowed_hosts: None,
         audit_log_path: None,
         discover: false,
+        forwards: &[],
     });
 }


### PR DESCRIPTION
Three features that ended up touching overlapping files (config.rs, cmd/exec.rs, main.rs), so they're shipping together.

### TCP port forwarding

Adds `--forward SPEC` to `redan exec`. The guest connects to `gateway:guest_port`, redan relays raw bytes to `127.0.0.1:host_port`. Same threading model as the SSH relay: two threads per connection, mpsc channels, `shuttle_bytes()` unchanged. No inspection, no injection, no scrubbing. Target is always localhost, the guest can't influence the destination.

Reserved ports (22, 53, 80, 443) are rejected at parse time. Config supports both CLI (`--forward 9222`) and redan.toml (`[network] forward = ["9222", "8080:3000"]`), merged together with duplicate guest-port detection. `host_matches()` is now `pub` because the browser allowlist proxy will need it in a follow-up.

`ForwardSpec`, `parse_forward_spec()`, `BacklogKind::TcpForward`, `ConnKind::TcpForward`, and `tcp_forward_thread()` all live in proxy.rs. Audit events: `forward_connect` / `forward_disconnect`. 11 unit tests cover the parser.

### Generic agent registry

Replaces the Claude-Code-specific detection in auto_detect.rs with a data-driven approach. Each agent is a static `AgentDef` with its auth methods (`ApiKeyDef` for env-var secrets, `OAuthDef` for stored credentials), required hosts, and runtime config. Adding a new agent means adding an entry to `AGENTS`, the detection and config-building logic is generic.

OAuth detection mounts `~/.claude` read-only into the guest and copies `.credentials.json` to the writable workspace at boot. API key still takes precedence when both are available. Also adds init detections for Flutter, Java, Kotlin, Swift, and Elixir.

### Read-only mounts

Wires `:ro` support through the full stack: `read_only: bool` on `MountConfig`, `parse_mount()` returns a 3-tuple, `mount_specs()` appends `:ro`, `krun_add_virtiofs3` FFI binding, and `mount -t virtiofs -o ro` in the guest init script. The OAuth credential mount is the first consumer.

## Test plan

- [x] `mise run check` passes (format + clippy + 150 unit tests)
- [ ] `redan exec --forward 9222 -i` with a TCP echo server on host:9222, verify guest can connect
- [ ] `--forward 443` rejected at parse time
- [ ] Audit log contains `forward_connect` / `forward_disconnect`
- [ ] OAuth credential mount is read-only in guest

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add TCP port forwarding in `redan exec` via a new --forward option (guest→host localhost)
  * Support per-mount read-only mounts using the `:ro` suffix

* **Enhancements**
  * Auto-detection now recognizes Flutter/Dart, Java, Swift, and Elixir projects
  * Workspace mount is explicitly writable by default
  * Runtime and template outputs now include configured forwards for export and proxy setup

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getredan/redan/pull/53?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->