### PR TITLE
feat: browser support + guest non-root execution

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,6 @@
+[env]
+# smoltcp defaults IFACE_MAX_ADDR_COUNT to 2, which only fits the gateway IP
+# plus one mapped host. redan allocates a unique IP per DNS hostname (for
+# reverse-lookup on non-SNI protocols), so we need room for all of them.
+# The host pool range is .10-.254 (245 IPs), so 256 covers the gateway + pool.
+SMOLTCP_IFACE_MAX_ADDR_COUNT = "256"

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ operate.
 
 Auto-detect kicks in when there's no `redan.toml` and no explicit CLI
 flags. For OAuth-based auth (Claude Max/Team/Enterprise), redan detects
-your `~/.claude` credentials and mounts them read-only instead.
+your `~/.claude` credentials and stages them into the VM instead.
 
 ## Any agent
 
@@ -358,9 +358,9 @@ No Windows support (WSL2 with KVM passthrough may work, untested).
 
 ## Status
 
-Alpha. The full chain works end-to-end: `redan init --claude` through
-interactive Claude Code sessions with network policy enforcement.
-Pre-built binaries on
+Alpha. The full chain works end-to-end: zero-config `redan exec` through
+interactive Claude Code sessions with network policy enforcement, credential
+staging, and privilege separation. Pre-built binaries on
 [GitHub Releases](https://github.com/getredan/redan/releases).
 
 This code has not been through an independent security audit. Use at

--- a/README.md
+++ b/README.md
@@ -26,82 +26,51 @@ These aren't hypothetical. Every file the agent reads is a potential
 injection vector, and LLM prompt injection is an open problem with no
 general solution.
 
-Redan puts the agent in a microVM that boots in under a second. The
-agent gets a real dev environment, but it's isolated from your host.
-Own filesystem, own network, only the hosts you allow. Your API keys
-never enter the VM. Redan injects them at the network layer, only for
-the hosts you permit. Even if the agent is compromised by a prompt
-injection, it has no secret to steal and nowhere to send it.
-
-# What's Redan?
-
-Redan uses [libkrun] microVMs (sub-second boot) and a userspace TCP/IP
-stack to sandbox AI agents. The agent gets a full Linux environment with
-your project files mounted in, but runs in its own VM with its own
-filesystem and a network proxy that enforces a host allowlist. Secrets
-are injected into HTTPS request headers by the proxy on the host side,
-so they never exist inside the VM.
-
-Works with Claude Code, Codex, Copilot, Cursor, or any command-line AI
-agent.
+Redan puts the agent in a [libkrun] microVM that boots in under a second.
+The agent gets a real Linux dev environment with your project mounted in,
+but it's isolated from your host: own filesystem, own network, only the
+hosts you allow. Your API keys never enter the VM. Redan injects them at
+the network layer, only for the hosts you permit. Even if the agent is
+fully compromised, it has no secret to steal and nowhere to send it.
 
 > *redan (/ɹɪˈdan/): a V-shaped fieldwork forming a salient angle toward
 > the enemy.*
 
-## Installation
+## Getting started
 
-Redan requires Linux with KVM (`/dev/kvm`) and libkrun.
+Redan requires Linux with KVM (`/dev/kvm`) and [libkrun].
 
-### Arch Linux
+**Install libkrun:**
 
 ```bash
+# Arch
 pacman -S libkrun
-```
 
-### Fedora
-
-```bash
+# Fedora
 dnf install libkrun-devel
-```
 
-### Ubuntu / Debian
-
-libkrun is not yet in the Ubuntu/Debian repositories. Build from source:
-
-```bash
+# Ubuntu/Debian (not yet in repos, build from source)
 apt install build-essential libkrunfw-dev
 git clone https://github.com/containers/libkrun
 cd libkrun && make && sudo make install
 ```
 
-### Then install redan
+**Install redan:**
 
-[Pre-built binaries for Linux x86_64 and aarch64 are available on the
-releases page.](https://github.com/getredan/redan/releases) Download,
-extract, and move to your `$PATH`:
-
-```bash
-tar xzf redan-*.tar.gz
-sudo mv redan /usr/local/bin/
-```
-
-Or build from source (requires Rust 1.85+, edition 2024):
+[Pre-built binaries](https://github.com/getredan/redan/releases) for
+Linux x86_64 and aarch64, or build from source (Rust 1.92+):
 
 ```bash
 cargo install --git https://github.com/getredan/redan.git
 ```
 
-Verify everything works:
+**Verify:**
 
 ```bash
 redan doctor
 ```
 
-## Setup with Claude Code
-
-### Zero-config (recommended)
-
-Set your API key and run:
+## Claude Code (zero-config)
 
 ```bash
 export ANTHROPIC_API_KEY=sk-ant-...
@@ -120,238 +89,170 @@ It prints what it chose so nothing is silent:
   Mounting current directory → /workspace
 ```
 
+Git remote hosts are added to the network allowlist automatically so
+git push/pull works out of the box. The agent runs as an unprivileged
+user inside the VM (not root), matching how Claude Code expects to
+operate.
+
 Auto-detect kicks in when there's no `redan.toml` and no explicit CLI
-flags. Git remote hosts are added to the network allowlist so git works
-out of the box. Host files like `~/.ssh` and `~/.gitconfig` are not
-mounted by default (they'd be writable by the guest). Add them via
-`redan.toml` if you need them -- `redan init` generates commented-out
-examples.
+flags. For OAuth-based auth (Claude Max/Team/Enterprise), redan detects
+your `~/.claude` credentials and mounts them read-only instead.
 
-### With redan.toml
+## Any agent
 
-For repeatable setups, use `redan init`:
+Redan works with any command-line AI agent. Build an image, tell redan
+what to run and what hosts to allow:
 
 ```bash
-redan init --claude
-redan image import myproject --devcontainer .devcontainer/redan
-redan exec
+redan image create myimage --packages "python3 nodejs npm"
+redan exec --image myimage \
+  --secret "API_KEY=env://MY_API_KEY:api.example.com" \
+  --mount ./my-project \
+  -- my-agent --some-flag
 ```
 
-`redan init --claude` generates a devcontainer with Claude Code, Node.js,
-and project-appropriate tooling (Python/uv, Rust, Go, etc.) plus a
-`redan.toml` with Anthropic API hosts pre-configured.
-
-### Manual
-
-```bash
-redan image import claude-code --dockerfile dockerfiles/claude-code.dockerfile
-redan exec --image claude-code -i \
-  --secret "ANTHROPIC_API_KEY=sk-ant-...:api.anthropic.com" \
-  --mount ./my-project
-```
-
-## Configuration
-
-Use `redan.toml` instead of long CLI invocations. `redan init` generates
-one from project detection:
-
-```bash
-redan init          # detect project type, generate config
-redan init --claude # generate config + devcontainer for Claude Code
-```
-
-Example `redan.toml`:
+Or use `redan.toml` for repeatable setups:
 
 ```toml
-image = "myproject"
-command = "claude --dangerously-skip-permissions"
+image = "myimage"
+command = "my-agent --some-flag"
 interactive = true
 
 [network]
-allow = ["api.anthropic.com", "pypi.org"]
+allow = ["api.example.com", "registry.npmjs.org"]
 
-[secrets.ANTHROPIC_API_KEY]
-value = "sk-ant-..."
-hosts = ["api.anthropic.com"]
+[secrets.API_KEY]
+value = "env://MY_API_KEY"
+hosts = ["api.example.com"]
 
 [mount.workspace]
 source = "."
 target = "/workspace"
 
 [env]
-CLAUDE_CONFIG_DIR = "/workspace/.claude"
+MY_SETTING = "value"
 ```
 
-Looks for `redan.toml` in the current directory, then
-`~/.config/redan/config.toml`. CLI flags override file values.
-
-Redan also reads `sandbox.network.allowedDomains` from Claude Code
-settings (`.claude/settings.json` and `~/.claude/settings.json`) and
-merges them into the network allowlist automatically.
-
-## Quick start
-
-### Run an agent (zero-config)
-
-```bash
-export ANTHROPIC_API_KEY=sk-ant-...
-redan exec
-```
-
-The agent sees `$ANTHROPIC_API_KEY` as a placeholder token. The proxy
-injects the real key only in HTTPS requests to `api.anthropic.com`.
-Responses are scrubbed of the real value before the agent sees them.
-
-### Run in the background
-
-```bash
-redan exec -d --name my-agent
-redan logs my-agent -f           # tail the logs
-redan stop my-agent              # stop when done
-```
-
-### Run with explicit config
-
-```bash
-redan exec --image claude-code \
-  --secret "ANTHROPIC_API_KEY=sk-ant-...:api.anthropic.com" \
-  --mount ./my-project \
-  -- claude --print "review this project"
-```
-
-**Note:** `--secret` literal values are visible in process listings (`ps`).
-For production use, prefer `env://`, `vault://`, or `--secret-file`,
-which keep secrets out of process listings by having redan read them
-internally.
-
-### Check prerequisites
-
-```bash
-redan doctor                         # system checks
-redan doctor --image myimage         # check a specific image exists
-redan doctor --secret "KEY=val:host" # validate secret syntax + providers
-```
-
-Checks for /dev/kvm, libkrun, libkrunfw, available images, and
-whether `ANTHROPIC_API_KEY` is set (for zero-config Claude Code).
-
-## How it works
-
-```
-Guest VM (libkrun, <1s boot)
-  |
-  |  virtio-fs (project dir read-write)
-  |  virtio-net (ethernet frames over unix socket)
-  v
-smoltcp (userspace TCP/IP on host)
-  |
-  |-- UDP :53  -> synthetic DNS (per-host IP allocation)
-  |-- TCP :22  -> transparent relay (allowlist checked, no injection)
-  |-- TCP :80  -> rejected (HTTPS only)
-  |-- TCP :443 -> TLS MITM proxy
-        |
-        |-- SNI extraction
-        |-- ephemeral cert (signed by per-session CA)
-        |-- secret injection (headers only, host-allowlisted)
-        |-- request forwarded to real upstream
-        |-- response scrubbed of secret values
-        |-- streamed back to guest
-```
-
-**Key properties:**
-- Guest never sees real secret values (only placeholders)
-- Secrets are injected only for explicitly allowed hosts
-- Injection is restricted to HTTP headers (not URLs, not bodies)
-- DNS is synthetic -- each hostname gets a unique IP, no queries leave the host
-- All traffic routes through the gateway IP (no direct IP access)
-- Default-deny outbound networking
-- Response scrubbing is best-effort (literal byte match)
+`redan init` generates a config from project detection. `redan init --claude`
+adds a devcontainer with Claude Code, Node.js, and project-appropriate
+tooling.
 
 ## Secrets
 
-Format: `ENV_VAR=value:allowed_host1,allowed_host2`
-
-The value can be a literal or a provider URI:
+Secrets are injected into HTTPS request headers by the proxy on the host
+side. The agent only sees placeholder tokens. Format:
+`ENV_VAR=value:allowed_hosts`
 
 ```bash
-# Literal value
+# Literal
 --secret "GITHUB_TOKEN=ghp_abc123:api.github.com"
 
-# From host environment variable
+# From host env var (read at startup, never passed to VM)
 --secret "GITHUB_TOKEN=env://GITHUB_TOKEN:api.github.com"
 
-# From HashiCorp Vault (KV v2)
---secret "GITHUB_TOKEN=vault://secret/myapp#github_token:api.github.com"
+# From HashiCorp Vault KV v2
+--secret "API_KEY=vault://secret/myapp#api_key:api.example.com"
 
 # Multiple hosts
 --secret "API_KEY=sk-abc:api.example.com,cdn.example.com"
 
 # From a file (one spec per line, # comments)
 --secret-file .redan-secrets
+```
 
-# Multiple secrets
---secret "GITHUB_TOKEN=env://GITHUB_TOKEN:api.github.com" \
---secret "NPM_TOKEN=vault://secret/myapp#npm_token:registry.npmjs.org"
+`env://` and `vault://` keep secrets out of process listings. Vault
+falls back to `~/.vault-token` if `VAULT_TOKEN` is not set.
+
+**Note:** Redan injects into HTTP headers only. Auth patterns that need
+secrets in request bodies (OAuth token exchanges, AWS SigV4), TLS
+handshakes (mTLS), or cookies are not supported for injection. Redan
+still provides VM isolation and network restriction for those cases,
+you just pass the credential via environment variable.
+
+## Network policy
+
+Default-deny outbound. You must explicitly allow hosts:
+
+```bash
+redan exec --allow-host api.anthropic.com --allow-host registry.npmjs.org
+```
+
+Wildcard patterns work: `"*.amazonaws.com"` matches any subdomain.
+Hosts required by secrets are included automatically. Connections to
+private IP ranges (RFC 1918, link-local, cloud metadata) are blocked
+even in allow-all mode. Domain fronting is blocked: HTTP Host must
+match TLS SNI.
+
+**Discover mode** lets you figure out what hosts the agent needs:
+
+```bash
+redan exec --discover -- my-agent --some-flag
+```
+
+Redan allows all connections, prints the observed hosts at exit, and
+generates a `[network]` config block you can paste into `redan.toml`.
+
+## Browser support
+
+For agents that need web access (research, testing, scraping), redan
+can launch headless Chrome on the host with CDP (Chrome DevTools
+Protocol) access from the guest:
+
+```bash
+redan exec --browser --allow-host "*.example.com"
+```
+
+Chrome runs on the host, not in the VM. Its outbound traffic goes
+through an allowlist proxy that enforces the same host restrictions
+as the main proxy, including SSRF protection for private IPs. The
+agent controls Chrome via CDP through port forwarding.
+
+The guest gets these env vars:
+- `REDAN_BROWSER=1`
+- `REDAN_BROWSER_HOST` (gateway IP to connect to)
+- `REDAN_BROWSER_CDP_PORT` (CDP port, default 9222)
+
+Chrome's sandbox stays enabled. The VM isolates the agent, Chrome's
+sandbox protects the host.
+
+Requires Chromium or Google Chrome installed on the host.
+`redan doctor` checks for it.
+
+## Port forwarding
+
+Forward TCP ports from guest to host, useful for dev servers, databases,
+or services running on the host that the agent needs to reach:
+
+```bash
+# Same port both sides
+redan exec --forward 8080
+
+# Different ports: guest connects to 3000, redan relays to host 8080
+redan exec --forward 3000:8080
 ```
 
 In `redan.toml`:
 
 ```toml
-[secrets.GITHUB_TOKEN]
-value = "env://GITHUB_TOKEN"
-hosts = ["api.github.com"]
+[network]
+forward = ["8080", "3000:8080"]
 ```
 
-### Environment variable provider
-
-`env://VAR_NAME` reads the secret from a host environment variable at
-session start. The variable is read on the host and never passed into
-the VM.
-
-```bash
-export GITHUB_TOKEN=ghp_abc123
-redan exec --secret "GITHUB_TOKEN=env://GITHUB_TOKEN:api.github.com"
-```
-
-Fails loudly if the variable is not set or is empty.
-
-### Vault integration
-
-Redan reads secrets from HashiCorp Vault KV v2 via `vault://path#field`.
-Configure with standard Vault environment variables:
-
-```bash
-export VAULT_ADDR='https://vault.example.com:8200'
-export VAULT_TOKEN='hvs.xxx'
-
-redan exec --image claude-code \
-  --secret "API_KEY=vault://myapp/prod#api_key:api.example.com"
-```
-
-Falls back to `~/.vault-token` if `VAULT_TOKEN` is not set.
-
-### Provider architecture
-
-Secret resolution is pluggable via the `SecretProvider` trait. The open
-core ships with `Literal`, `Env`, and `Vault` providers. The trait is
-designed for extension -- additional backends (AWS Secrets Manager,
-1Password, etc.) can be added in the future.
-
-The value can contain colons (splits on the last `:`). The guest
-receives a `redan_ph_<name>_<hex>` placeholder via environment variable.
+The guest connects to the gateway IP on the guest port; redan relays
+to `127.0.0.1` on the host port.
 
 ## Mounts
 
 ```bash
-# Mount to /workspace (default)
---mount /home/chris/project
-
-# Mount to specific guest path
---mount /home/chris/project:/code
+--mount /home/chris/project              # mounts to /workspace
+--mount /home/chris/project:/code        # custom guest path
+--mount /home/chris/.config/tool:ro      # read-only
+--mount /home/chris/.ssh:/ssh-keys:ro    # host config, read-only
 ```
 
 Uses virtio-fs for host directory sharing. The guest has read-write
-access, and git is your safety net for recovering from unwanted changes.
+access by default. Append `:ro` for read-only. Git is your safety net
+for recovering from unwanted changes to mounted directories.
 
 ## Image management
 
@@ -361,240 +262,105 @@ redan image import myimage --from ubuntu:24.04
 redan image import myimage --dockerfile path/to/Dockerfile
 redan image import myimage --devcontainer .devcontainer
 redan image list
-redan image update myimage
+redan image update myimage    # rebuild from original source
 redan image remove myimage
 ```
 
-`create` builds Alpine-based images with apk packages. `import` pulls
-from Docker images, builds from Dockerfiles, or reads devcontainer
-configs (`build.dockerfile`, `image`, and `dockerComposeFile` are all
-supported).
-
-Images are rootfs directories stored at `~/.local/share/redan/images/`
-and base tarballs are cached at `~/.cache/redan/`.
-
-### Image freshness
-
-Redan tracks when images were built and from what source. `redan image
-list` shows the age of each image, `redan doctor` warns about images
-older than 30 days, and `redan exec` prints a non-blocking warning
-before launching.
-
-```bash
-redan image update claude-code   # rebuild from the original Dockerfile
-```
-
-`redan image update` remembers how the image was built (Dockerfile,
-Docker image, devcontainer, or `create` args) and rebuilds from
-the same source.
-
-## Network policy
-
-Redan defaults to **deny-all** outbound networking. You must explicitly
-allow hosts:
-
-```toml
-[network]
-allow = ["api.anthropic.com", "registry.npmjs.org"]
-```
-
-Or on the CLI:
-
-```bash
-redan exec --allow-host api.anthropic.com --allow-host registry.npmjs.org
-```
-
-Wildcard patterns are supported: `"*.amazonaws.com"` matches any
-subdomain. Hosts required by secrets are automatically included.
-Use `"*"` to allow all outbound connections (not recommended).
-
-Connections to private IP ranges (RFC 1918, link-local, cloud metadata
-endpoints) are blocked by default, even in allow-all mode. Hosts
-explicitly in the allowlist may resolve to private IPs -- add
-`"localhost"` if you need local services.
-
-Domain fronting is blocked: requests where the HTTP Host header doesn't
-match the TLS SNI hostname are rejected (HTTP 421).
-
-### Discover mode
-
-Don't know what hosts your agent needs? Run once in discover mode:
-
-```bash
-redan exec --image myimage --discover -- claude --print "build this project"
-```
-
-Redan allows all connections and prints the observed hosts at exit:
-
-```
---- discovered hosts ---
-The agent connected to these hosts:
-
-  api.anthropic.com
-  registry.npmjs.org
-
-Suggested redan.toml:
-
-[network]
-allow = [
-    "api.anthropic.com",
-    "registry.npmjs.org",
-]
-```
-
-Copy the output into your `redan.toml` and subsequent runs enforce it.
+`create` builds Alpine-based images. `import` pulls from Docker images,
+Dockerfiles, or devcontainer configs. `update` remembers how the image
+was built and rebuilds from the same source. `redan doctor` warns about
+images older than 30 days.
 
 ## Sessions
 
-Each `redan exec` creates a session with a unique ID. Session metadata,
-logs, and audit events are stored at `~/.local/state/redan/sessions/`.
-
-### Detached sessions
-
-Run agents in the background:
-
 ```bash
-redan exec -d                    # detach, auto-generated ID
-redan exec -d --name my-agent    # detach with a name
-```
+redan exec -d --name my-agent    # run in background
+redan logs my-agent -f           # tail the logs
+redan attach my-agent            # reconnect
+redan stop my-agent              # SIGTERM, wait 3s, SIGKILL
 
-### Session management
-
-```bash
-redan sessions                # list all sessions
-redan sessions show <id>      # session details
-redan sessions remove         # remove all exited sessions
-redan sessions remove <id>    # remove a specific session
-```
-
-### Attach and stop
-
-```bash
-redan attach                  # attach to most recent running session
-redan attach my-agent         # attach by name or ID prefix
-redan stop                    # stop most recent running session
-redan stop my-agent           # stop by name or ID prefix
-```
-
-`redan stop` sends SIGTERM, waits 3 seconds, then SIGKILL.
-
-### Logs
-
-```bash
-redan logs                    # logs from most recent session
-redan logs -f                 # tail -f
-redan logs my-agent           # logs by name or session ID
+redan sessions                   # list all
+redan sessions show <id>         # details
+redan sessions remove            # clean up exited sessions
 ```
 
 ## Audit log
 
 ```bash
-redan exec --audit-log events.jsonl ...
+redan exec --audit-log events.jsonl
 ```
 
-Structured JSON-lines event log for security audit and debugging:
-
-```jsonl
-{"ts":"...","event":"connect","host":"api.github.com"}
-{"ts":"...","event":"inject","host":"api.github.com","env":"API_KEY"}
-{"ts":"...","event":"scrub","host":"api.github.com"}
-{"ts":"...","event":"reject","host":"evil.com","reason":"not_allowed"}
-```
-
-Audit logs are also stored per-session automatically.
+JSON-lines event log: connections, injections, scrubs, rejections.
+Also stored per-session automatically.
 
 ## Agent awareness
 
-Redan exposes network policy to the guest so AI agents can understand
-their environment instead of guessing "the internet is broken":
+Redan tells the guest about its environment so agents can adapt
+instead of hitting mysterious "connection failed" errors:
 
-**Environment variables:**
-- `REDAN=1` -- running inside a redan sandbox
-- `REDAN_NETWORK=restrict|deny-all|allow-all` -- policy mode
-- `REDAN_ALLOWED_HOSTS=host1,host2,...` -- permitted outbound hosts
+- `REDAN=1` (running in a redan sandbox)
+- `REDAN_NETWORK=restrict|deny-all|allow-all` (policy mode)
+- `REDAN_ALLOWED_HOSTS=host1,host2,...` (permitted hosts)
+- `/etc/redan/policy` (human-readable policy file)
 
-**Policy file:** `/etc/redan/policy` -- human-readable description of
-what's allowed and what's blocked.
+## How it works
 
-Agents that check `$REDAN` can adapt their behavior: skip web searches,
-avoid fetching URLs outside the allowlist, and give users clear error
-messages instead of "connection failed".
+```
+Guest VM (libkrun, <1s boot)
+  |
+  |  virtio-fs (project dir)
+  |  virtio-net (ethernet frames over unix socket)
+  v
+smoltcp (userspace TCP/IP on host)
+  |
+  |-- UDP :53  -> synthetic DNS (per-host IP allocation)
+  |-- TCP :22  -> transparent relay (allowlist checked)
+  |-- TCP :80  -> rejected (HTTPS only)
+  |-- TCP :443 -> TLS MITM proxy
+  |     |-- SNI extraction, ephemeral cert
+  |     |-- secret injection (headers, host-scoped)
+  |     |-- response scrubbing (literal byte match)
+  |     '-- forwarded to real upstream
+  |-- TCP fwd -> port forwarding to host localhost
+  v
+internet (allowed hosts only)
+```
+
+DNS is synthetic (no queries leave the host), all traffic routes through
+the gateway (no direct IP access), and HTTP/1.1 only (HTTP/2 binary
+framing would bypass header parsing). SSH on port 22 is forwarded as-is
+with allowlist enforcement but no injection/scrubbing.
 
 ## Security model
 
-Redan's threat model: a compromised or malicious AI agent running inside
-the VM tries to exfiltrate secrets or access unauthorized resources.
+Redan's threat model: a compromised or malicious AI agent inside the VM
+tries to exfiltrate secrets or access unauthorized resources.
 
-**What redan prevents:**
-- Agent reading real secret values from environment
-- Agent sending secrets to unauthorized hosts
-- Agent making DNS queries to the internet
-- Agent connecting directly to IP addresses (all traffic goes through proxy)
-- Agent reaching hosts not in the allowlist (default-deny networking)
+**What redan prevents:** agent reading real secret values, sending
+secrets to unauthorized hosts, making DNS queries to the internet,
+connecting directly to IP addresses, reaching hosts not in the
+allowlist.
 
-**Known limitations:**
-- Scrubbing doesn't catch encoded secrets (base64, URL-encoding, etc.)
-- No HTTP request body inspection (secrets in headers only)
-
+**Known limitations:** scrubbing is literal byte match (doesn't catch
+base64/URL-encoded secrets), no request body inspection, HTTP/1.1 only.
 Primary defense is the host allowlist, not scrubbing. Scrubbing reduces
 accidental exposure; it's not a hard security boundary.
 
 See [docs/security-model.md](docs/security-model.md) for the full
-threat model, side-channel analysis, and known limitations.
+threat model and side-channel analysis.
 
-## Limitations
+## Platform
 
-Be aware of what redan does and doesn't support before deploying it.
+Linux only. Requires KVM (`/dev/kvm`). x86_64 and aarch64.
 
-### Supported auth patterns
-
-- `Authorization: Bearer <token>` -- standard API key injection
-- Custom headers (`X-Api-Key`, etc.) -- any header-based auth
-- Multiple secrets to multiple hosts in one session
-
-### Unsupported auth patterns
-
-These patterns require secrets in places redan currently can't inject:
-
-- **OAuth flows** -- token exchanges happen in request/response bodies
-- **AWS SigV4** -- request signing requires the secret at the call site
-  to compute HMAC over headers and body
-- **Client certificates** -- mTLS requires the cert in the TLS handshake,
-  which redan terminates
-- **Body-embedded tokens** -- GraphQL variables, form fields, JSON bodies
-  carrying auth tokens
-- **Cookie-based auth** -- `Set-Cookie` from login flows, session tokens
-
-If your API requires one of these, redan can still provide VM isolation
-and network restriction, but can't inject or scrub the credential.
-Pass it via environment variable (the guest sees the real value).
-
-### Protocol constraints
-
-- **HTTP/1.1 only.** Redan forces ALPN to `http/1.1`. All major APIs
-  (Anthropic, OpenAI, GitHub, npm) support HTTP/1.1. If a server
-  requires HTTP/2, it won't work through redan.
-- **No WebSocket.** Upgrade requests return 501. Binary framing after
-  the upgrade would bypass scrubbing.
-- **SSH is transparent.** Port 22 connections are forwarded as-is to
-  the real upstream server. No secret injection or scrubbing -- SSH
-  handles its own authentication. The allowlist still applies.
-- **No other raw TCP/UDP.** Database connections, gRPC (over H2), and
-  other protocols are not currently supported.
-- **HTTPS only.** Plain HTTP on port 80 is rejected.
-
-### Platform
-
-- **Linux only.** Requires KVM (`/dev/kvm`). libkrun supports macOS
-  via Hypervisor.framework but this is untested.
-- **x86_64 and aarch64.** Other architectures are untested.
-- **No Windows.** WSL2 with KVM passthrough may work but is untested.
+libkrun supports macOS via Hypervisor.framework but this is untested.
+No Windows support (WSL2 with KVM passthrough may work, untested).
 
 ## Status
 
-**Alpha.** The full chain works end-to-end: `redan init --claude` through
+Alpha. The full chain works end-to-end: `redan init --claude` through
 interactive Claude Code sessions with network policy enforcement.
-Pre-built binaries for Linux x86_64 and aarch64 on
+Pre-built binaries on
 [GitHub Releases](https://github.com/getredan/redan/releases).
 
 This code has not been through an independent security audit. Use at
@@ -606,10 +372,10 @@ If redan is useful to you, consider [buying me a coffee](https://buymeacoffee.co
 
 ## Acknowledgments
 
-- [libkrun] and [libkrunfw] -- microVM engine and guest firmware
-- [smoltcp] -- userspace TCP/IP stack
-- [rustls] and [rcgen] -- TLS implementation and certificate generation
-- [Gondolin] -- network-layer secret injection pattern for agent sandboxes
+- [libkrun] and [libkrunfw] for the microVM engine and guest firmware
+- [smoltcp] for the userspace TCP/IP stack
+- [rustls] and [rcgen] for TLS and certificate generation
+- [Gondolin] for the network-layer secret injection pattern
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ instead of hitting mysterious "connection failed" errors:
 
 ## How it works
 
-```
+```text
 Guest VM (libkrun, <1s boot)
   |
   |  virtio-fs (project dir)

--- a/dockerfiles/claude-code.dockerfile
+++ b/dockerfiles/claude-code.dockerfile
@@ -14,8 +14,10 @@ RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_MAJOR}.x | bash - && \
 # Claude Code
 RUN npm install -g @anthropic-ai/claude-code
 
-# Non-root user
-RUN groupadd --gid 1000 dev && \
+# Non-root user (ubuntu:24.04 ships with ubuntu:1000, remove it first)
+RUN userdel -r ubuntu 2>/dev/null; \
+    groupdel ubuntu 2>/dev/null; \
+    groupadd --gid 1000 dev && \
     useradd --uid 1000 --gid 1000 -m -s /bin/bash dev && \
     mkdir -p /workspace && chown dev:dev /workspace
 

--- a/dockerfiles/pi.dockerfile
+++ b/dockerfiles/pi.dockerfile
@@ -1,0 +1,26 @@
+FROM ubuntu:24.04
+
+RUN apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends \
+      ca-certificates curl git iproute2 && \
+    rm -rf /var/lib/apt/lists/*
+
+# Node.js via NodeSource
+ARG NODE_MAJOR=22
+RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_MAJOR}.x | bash - && \
+    apt-get install -y -qq --no-install-recommends nodejs && \
+    rm -rf /var/lib/apt/lists/*
+
+# Pi coding agent
+RUN npm install -g @earendil-works/pi-coding-agent
+
+# Non-root user (ubuntu:24.04 ships with ubuntu:1000, remove it first)
+RUN userdel -r ubuntu 2>/dev/null; \
+    groupdel ubuntu 2>/dev/null; \
+    groupadd --gid 1000 dev && \
+    useradd --uid 1000 --gid 1000 -m -s /bin/bash dev && \
+    mkdir -p /workspace && chown dev:dev /workspace
+
+USER dev
+WORKDIR /workspace
+CMD ["pi"]

--- a/mise.toml
+++ b/mise.toml
@@ -31,7 +31,9 @@ run = "cargo test --lib"
 
 [tasks.test-integration]
 description = "Run integration tests (requires KVM + /tmp/redan-rootfs)"
-run = "cargo test --test integration -- --ignored"
+# Serialized: Vm::boot forks, and forking from a threaded test harness
+# can deadlock the child on locks held by other test threads.
+run = "cargo test --test integration -- --ignored --test-threads=1"
 
 [tasks.build]
 description = "Build release binary"

--- a/mise.toml
+++ b/mise.toml
@@ -37,6 +37,10 @@ run = "cargo test --test integration -- --ignored"
 description = "Build release binary"
 run = "cargo build --release"
 
+[tasks.install]
+description = "Build and install to ~/.cargo/bin"
+run = "cargo install --path ."
+
 [tasks.bench]
 description = "Boot-to-proxy benchmark (requires KVM + image)"
 run = "./tests/bench_boot.sh"

--- a/src/auto_detect.rs
+++ b/src/auto_detect.rs
@@ -20,7 +20,7 @@ use crate::image;
 /// All known agents, ordered by detection priority.
 /// `detect()` returns the first match; `detect_all()` returns every match
 /// (for a future interactive picker).
-static AGENTS: &[&AgentDef] = &[&CLAUDE_CODE];
+static AGENTS: &[&AgentDef] = &[&CLAUDE_CODE, &PI];
 
 static CLAUDE_CODE: AgentDef = AgentDef {
     name: "Claude Code",
@@ -42,12 +42,37 @@ static CLAUDE_CODE: AgentDef = AgentDef {
         inject_hosts: &["api.anthropic.com"],
         guest_env: &[("CLAUDE_CONFIG_DIR", "/workspace/.claude")],
     }),
-    oauth: Some(OAuthDef {
+    stored_credentials: Some(StoredCredentialsDef {
         home_dir: ".claude",
         credentials_file: ".credentials.json",
-        guest_credentials_dir: "/tmp/.claude",
+        stage_files: &[".credentials.json"],
+        guest_dir: "/tmp/.claude",
         guest_env: &[("CLAUDE_CONFIG_DIR", "/tmp/.claude")],
         extra_hosts: &["auth.anthropic.com", "console.anthropic.com"],
+    }),
+};
+
+static PI: AgentDef = AgentDef {
+    name: "Pi",
+    image: "pi",
+    command: "pi",
+    hosts: &["api.anthropic.com"],
+    interactive: true,
+    timeout_secs: 3600,
+    run_as: Some("dev"),
+    guest_env: &[("HOME", "/home/dev")],
+    api_key: Some(ApiKeyDef {
+        env_var: "ANTHROPIC_API_KEY",
+        inject_hosts: &["api.anthropic.com"],
+        guest_env: &[],
+    }),
+    stored_credentials: Some(StoredCredentialsDef {
+        home_dir: ".pi/agent",
+        credentials_file: "auth.json",
+        stage_files: &["auth.json", "settings.json", "models.json"],
+        guest_dir: "/home/dev/.pi/agent",
+        guest_env: &[],
+        extra_hosts: &[],
     }),
 };
 
@@ -71,8 +96,8 @@ pub struct AgentDef {
     pub guest_env: &'static [(&'static str, &'static str)],
     /// API-key-based auth (tried first).
     pub api_key: Option<ApiKeyDef>,
-    /// OAuth/stored-credentials auth (fallback when no API key).
-    pub oauth: Option<OAuthDef>,
+    /// Stored credentials auth (fallback when no API key).
+    pub stored_credentials: Option<StoredCredentialsDef>,
 }
 
 /// Auth via an environment variable injected as a redan secret.
@@ -87,16 +112,18 @@ pub struct ApiKeyDef {
 
 /// Auth via credentials stored in a config directory on the host.
 ///
-/// The credentials file is staged into the guest rootfs before boot
-/// (same pattern as CA cert installation), so no mount or runtime
-/// copy is needed.
-pub struct OAuthDef {
+/// Files are staged into the guest rootfs before boot (same pattern
+/// as CA cert installation), so no mount or runtime copy is needed.
+pub struct StoredCredentialsDef {
     /// Config directory relative to `$HOME` (e.g., `.claude`).
     pub home_dir: &'static str,
     /// File that signals credentials exist (e.g., `.credentials.json`).
     pub credentials_file: &'static str,
-    /// Guest directory to stage the credentials file into.
-    pub guest_credentials_dir: &'static str,
+    /// Files to stage from `home_dir` into the guest.
+    /// If empty, only `credentials_file` is staged.
+    pub stage_files: &'static [&'static str],
+    /// Guest directory to stage files into.
+    pub guest_dir: &'static str,
     /// Guest env vars to set when using this auth path.
     pub guest_env: &'static [(&'static str, &'static str)],
     /// Extra network hosts for token exchange.
@@ -116,9 +143,9 @@ pub struct AutoDetected {
     pub needs_image_build: bool,
     /// Run the user command as this OS user (via `runuser`).
     pub run_as: Option<&'static str>,
-    /// Credentials file to stage into the guest rootfs before boot.
-    /// (`host_path`, `guest_dir`, `filename`)
-    pub stage_credentials: Option<(PathBuf, String, String)>,
+    /// Files to stage into the guest rootfs before boot.
+    /// Each entry: (`host_path`, `guest_dir`, `filename`)
+    pub stage_files: Vec<(PathBuf, String, String)>,
 }
 
 /// A detected agent with its resolved auth method.
@@ -131,7 +158,7 @@ pub struct DetectedAgent {
 /// The auth method that was actually found in the environment.
 pub enum ResolvedAuth {
     ApiKey,
-    OAuth { host_config_dir: PathBuf },
+    StoredCredentials { host_config_dir: PathBuf },
 }
 
 // ---------------------------------------------------------------------------
@@ -155,10 +182,8 @@ pub fn detect_all() -> Vec<DetectedAgent> {
                 .as_ref()
                 .and_then(|a| std::env::var(a.env_var).ok());
             let oauth_creds = home.as_ref().and_then(|h| {
-                let oauth = agent.oauth.as_ref()?;
-                let path = Path::new(h)
-                    .join(oauth.home_dir)
-                    .join(oauth.credentials_file);
+                let sc = agent.stored_credentials.as_ref()?;
+                let path = Path::new(h).join(sc.home_dir).join(sc.credentials_file);
                 path.exists().then_some(path)
             });
             probe_with_env(agent, api_key_val.as_deref(), oauth_creds.as_deref(), None)
@@ -218,13 +243,13 @@ fn probe_with_env(
         });
     }
 
-    if agent.oauth.is_some()
+    if agent.stored_credentials.is_some()
         && let Some(creds_path) = oauth_credentials
     {
         let config_dir = creds_path.parent().unwrap_or(creds_path).to_path_buf();
         return Some(DetectedAgent {
             agent,
-            auth: ResolvedAuth::OAuth {
+            auth: ResolvedAuth::StoredCredentials {
                 host_config_dir: config_dir,
             },
             image_exists,
@@ -234,11 +259,69 @@ fn probe_with_env(
     None
 }
 
+fn apply_auth(
+    agent: &AgentDef,
+    auth: &ResolvedAuth,
+    config: &mut Config,
+    messages: &mut Vec<String>,
+    stage_files: &mut Vec<(PathBuf, String, String)>,
+    allow: &mut Vec<String>,
+) {
+    match auth {
+        ResolvedAuth::ApiKey => {
+            if let Some(api) = agent.api_key.as_ref() {
+                messages.push(format!(
+                    "Injecting {} for {}",
+                    api.env_var,
+                    api.inject_hosts.join(", ")
+                ));
+                config.secrets.insert(
+                    api.env_var.into(),
+                    SecretConfig {
+                        value: format!("env://{}", api.env_var),
+                        hosts: api.inject_hosts.iter().map(|&h| h.into()).collect(),
+                    },
+                );
+                for &(key, val) in api.guest_env {
+                    config.env.insert(key.into(), val.into());
+                }
+            }
+        }
+        ResolvedAuth::StoredCredentials { host_config_dir } => {
+            if let Some(sc) = agent.stored_credentials.as_ref() {
+                let files_to_stage = if sc.stage_files.is_empty() {
+                    vec![sc.credentials_file]
+                } else {
+                    sc.stage_files.to_vec()
+                };
+                for filename in &files_to_stage {
+                    let host_path = host_config_dir.join(filename);
+                    if host_path.exists() {
+                        messages.push(format!(
+                            "Staging {} → {}/{}",
+                            host_path.display(),
+                            sc.guest_dir,
+                            filename
+                        ));
+                        stage_files.push((host_path, sc.guest_dir.into(), (*filename).into()));
+                    }
+                }
+                for &(key, val) in sc.guest_env {
+                    config.env.insert(key.into(), val.into());
+                }
+                for &host in sc.extra_hosts {
+                    allow.push(host.to_string());
+                }
+            }
+        }
+    }
+}
+
 /// Turn a detected agent into a ready-to-use Config.
 fn build_config(detected: &DetectedAgent) -> AutoDetected {
     let agent = detected.agent;
     let mut messages = Vec::new();
-    let mut stage_credentials: Option<(PathBuf, String, String)> = None;
+    let mut stage_files: Vec<(PathBuf, String, String)> = Vec::new();
     let needs_image_build = !detected.image_exists;
 
     if detected.image_exists {
@@ -264,49 +347,14 @@ fn build_config(detected: &DetectedAgent) -> AutoDetected {
         config.env.insert(key.into(), val.into());
     }
 
-    match &detected.auth {
-        ResolvedAuth::ApiKey => {
-            if let Some(api) = agent.api_key.as_ref() {
-                messages.push(format!(
-                    "Injecting {} for {}",
-                    api.env_var,
-                    api.inject_hosts.join(", ")
-                ));
-                config.secrets.insert(
-                    api.env_var.into(),
-                    SecretConfig {
-                        value: format!("env://{}", api.env_var),
-                        hosts: api.inject_hosts.iter().map(|&h| h.into()).collect(),
-                    },
-                );
-                for &(key, val) in api.guest_env {
-                    config.env.insert(key.into(), val.into());
-                }
-            }
-        }
-        ResolvedAuth::OAuth { host_config_dir } => {
-            if let Some(oauth) = agent.oauth.as_ref() {
-                let cred_file = host_config_dir.join(oauth.credentials_file);
-                messages.push(format!(
-                    "Staging {} → {}/{}",
-                    cred_file.display(),
-                    oauth.guest_credentials_dir,
-                    oauth.credentials_file
-                ));
-                stage_credentials = Some((
-                    cred_file,
-                    oauth.guest_credentials_dir.into(),
-                    oauth.credentials_file.into(),
-                ));
-                for &(key, val) in oauth.guest_env {
-                    config.env.insert(key.into(), val.into());
-                }
-                for &host in oauth.extra_hosts {
-                    allow.push(host.to_string());
-                }
-            }
-        }
-    }
+    apply_auth(
+        agent,
+        &detected.auth,
+        &mut config,
+        &mut messages,
+        &mut stage_files,
+        &mut allow,
+    );
 
     let git_hosts = git_remote_hosts();
     if !git_hosts.is_empty() {
@@ -340,7 +388,7 @@ fn build_config(detected: &DetectedAgent) -> AutoDetected {
         messages,
         needs_image_build,
         run_as: agent.run_as,
-        stage_credentials,
+        stage_files,
     }
 }
 
@@ -458,7 +506,10 @@ mod tests {
 
         let detected = probe_with_env(&CLAUDE_CODE, None, Some(&creds), Some(true))
             .expect("should detect via OAuth");
-        assert!(matches!(detected.auth, ResolvedAuth::OAuth { .. }));
+        assert!(matches!(
+            detected.auth,
+            ResolvedAuth::StoredCredentials { .. }
+        ));
 
         let auto = build_config(&detected);
         assert_eq!(auto.config.image.as_deref(), Some("claude-code"));
@@ -471,7 +522,8 @@ mod tests {
         );
 
         // Credentials staged into rootfs before boot (no mount, no runtime copy)
-        let (host_path, guest_dir, filename) = auto.stage_credentials.as_ref().unwrap();
+        assert_eq!(auto.stage_files.len(), 1);
+        let (host_path, guest_dir, filename) = &auto.stage_files[0];
         assert_eq!(host_path, &creds);
         assert_eq!(guest_dir, "/tmp/.claude");
         assert_eq!(filename, ".credentials.json");
@@ -522,7 +574,10 @@ mod tests {
 
         let detected = probe_with_env(&CLAUDE_CODE, Some(""), Some(&creds), Some(true))
             .expect("should fall through to OAuth");
-        assert!(matches!(detected.auth, ResolvedAuth::OAuth { .. }));
+        assert!(matches!(
+            detected.auth,
+            ResolvedAuth::StoredCredentials { .. }
+        ));
 
         let _ = std::fs::remove_dir_all(&tmp);
     }
@@ -539,6 +594,57 @@ mod tests {
         let auto = build_config(&detected);
         assert!(auto.needs_image_build);
         assert!(auto.messages.iter().any(|m| m.contains("will build")));
+    }
+
+    #[test]
+    fn pi_api_key_produces_correct_config() {
+        let detected = probe_with_env(&PI, Some("sk-ant-test123"), None, Some(true))
+            .expect("should detect Pi via API key");
+        assert!(matches!(detected.auth, ResolvedAuth::ApiKey));
+
+        let auto = build_config(&detected);
+        assert_eq!(auto.config.image.as_deref(), Some("pi"));
+        assert_eq!(auto.config.command.as_deref(), Some("pi"));
+        assert_eq!(auto.run_as, Some("dev"));
+        assert_eq!(
+            auto.config.env.get("HOME").map(String::as_str),
+            Some("/home/dev")
+        );
+
+        let secret = auto.config.secrets.get("ANTHROPIC_API_KEY").unwrap();
+        assert_eq!(secret.value, "env://ANTHROPIC_API_KEY");
+        assert_eq!(secret.hosts, vec!["api.anthropic.com"]);
+    }
+
+    #[test]
+    fn pi_stored_credentials_stages_multiple_files() {
+        let tmp = std::env::temp_dir().join("redan-test-pi-creds");
+        let _ = std::fs::create_dir_all(&tmp);
+        let auth_file = tmp.join("auth.json");
+        let settings = tmp.join("settings.json");
+        std::fs::write(&auth_file, "{}").unwrap();
+        std::fs::write(&settings, "{}").unwrap();
+        // models.json intentionally absent: only existing files get staged
+
+        let detected = probe_with_env(&PI, None, Some(&auth_file), Some(true))
+            .expect("should detect Pi via stored credentials");
+        let auto = build_config(&detected);
+
+        assert_eq!(auto.stage_files.len(), 2);
+        let filenames: Vec<&str> = auto
+            .stage_files
+            .iter()
+            .map(|(_, _, f)| f.as_str())
+            .collect();
+        assert!(filenames.contains(&"auth.json"));
+        assert!(filenames.contains(&"settings.json"));
+        assert!(!filenames.contains(&"models.json"));
+
+        for (_, dir, _) in &auto.stage_files {
+            assert_eq!(dir, "/home/dev/.pi/agent");
+        }
+
+        let _ = std::fs::remove_dir_all(&tmp);
     }
 
     fn empty_flags() -> ExecFlags<'static> {

--- a/src/auto_detect.rs
+++ b/src/auto_detect.rs
@@ -336,6 +336,10 @@ fn build_config(detected: &DetectedAgent) -> AutoDetected {
     );
     messages.push("Mounting current directory → /workspace".into());
 
+    if crate::browser::find_chrome().is_some() {
+        messages.push("Chrome found: use --browser to enable headless browser access".into());
+    }
+
     AutoDetected {
         config,
         messages,

--- a/src/auto_detect.rs
+++ b/src/auto_detect.rs
@@ -45,14 +45,9 @@ static CLAUDE_CODE: AgentDef = AgentDef {
     oauth: Some(OAuthDef {
         home_dir: ".claude",
         credentials_file: ".credentials.json",
-        guest_mount: "/redan/host-claude-config",
+        guest_credentials_dir: "/tmp/.claude",
         guest_env: &[("CLAUDE_CONFIG_DIR", "/tmp/.claude")],
         extra_hosts: &["auth.anthropic.com", "console.anthropic.com"],
-        setup_command: Some(
-            "mkdir -p /tmp/.claude && \
-             cp /redan/host-claude-config/.credentials.json /tmp/.claude/.credentials.json && \
-             chmod 600 /tmp/.claude/.credentials.json",
-        ),
     }),
 };
 
@@ -90,22 +85,22 @@ pub struct ApiKeyDef {
     pub guest_env: &'static [(&'static str, &'static str)],
 }
 
-/// Auth via credentials stored in a config directory on the host,
-/// mounted read-only into the guest.
+/// Auth via credentials stored in a config directory on the host.
+///
+/// The credentials file is staged into the guest rootfs before boot
+/// (same pattern as CA cert installation), so no mount or runtime
+/// copy is needed.
 pub struct OAuthDef {
     /// Config directory relative to `$HOME` (e.g., `.claude`).
     pub home_dir: &'static str,
     /// File that signals credentials exist (e.g., `.credentials.json`).
     pub credentials_file: &'static str,
-    /// Where to mount the config dir read-only in the guest.
-    pub guest_mount: &'static str,
+    /// Guest directory to stage the credentials file into.
+    pub guest_credentials_dir: &'static str,
     /// Guest env vars to set when using this auth path.
     pub guest_env: &'static [(&'static str, &'static str)],
     /// Extra network hosts for token exchange.
     pub extra_hosts: &'static [&'static str],
-    /// Shell command to run before the agent command, e.g., copying
-    /// credentials from the read-only mount to a writable config dir.
-    pub setup_command: Option<&'static str>,
 }
 
 // ---------------------------------------------------------------------------
@@ -121,6 +116,9 @@ pub struct AutoDetected {
     pub needs_image_build: bool,
     /// Run the user command as this OS user (via `runuser`).
     pub run_as: Option<&'static str>,
+    /// Credentials file to stage into the guest rootfs before boot.
+    /// (`host_path`, `guest_dir`, `filename`)
+    pub stage_credentials: Option<(PathBuf, String, String)>,
 }
 
 /// A detected agent with its resolved auth method.
@@ -240,6 +238,7 @@ fn probe_with_env(
 fn build_config(detected: &DetectedAgent) -> AutoDetected {
     let agent = detected.agent;
     let mut messages = Vec::new();
+    let mut stage_credentials: Option<(PathBuf, String, String)> = None;
     let needs_image_build = !detected.image_exists;
 
     if detected.image_exists {
@@ -287,27 +286,23 @@ fn build_config(detected: &DetectedAgent) -> AutoDetected {
         }
         ResolvedAuth::OAuth { host_config_dir } => {
             if let Some(oauth) = agent.oauth.as_ref() {
+                let cred_file = host_config_dir.join(oauth.credentials_file);
                 messages.push(format!(
-                    "Mounting {} → {} (read-only, OAuth credentials)",
-                    host_config_dir.display(),
-                    oauth.guest_mount
+                    "Staging {} → {}/{}",
+                    cred_file.display(),
+                    oauth.guest_credentials_dir,
+                    oauth.credentials_file
                 ));
-                config.mount.insert(
-                    format!("{}-config", agent.image),
-                    MountConfig {
-                        source: host_config_dir.to_string_lossy().into_owned(),
-                        target: Some(oauth.guest_mount.into()),
-                        read_only: true,
-                    },
-                );
+                stage_credentials = Some((
+                    cred_file,
+                    oauth.guest_credentials_dir.into(),
+                    oauth.credentials_file.into(),
+                ));
                 for &(key, val) in oauth.guest_env {
                     config.env.insert(key.into(), val.into());
                 }
                 for &host in oauth.extra_hosts {
                     allow.push(host.to_string());
-                }
-                if let Some(setup) = oauth.setup_command {
-                    config.command = Some(format!("{setup} && {}", agent.command));
                 }
             }
         }
@@ -345,6 +340,7 @@ fn build_config(detected: &DetectedAgent) -> AutoDetected {
         messages,
         needs_image_build,
         run_as: agent.run_as,
+        stage_credentials,
     }
 }
 
@@ -468,21 +464,20 @@ mod tests {
         assert_eq!(auto.config.image.as_deref(), Some("claude-code"));
         assert!(auto.config.secrets.is_empty());
 
-        let mount = auto.config.mount.get("claude-code-config").unwrap();
-        assert!(mount.read_only);
-        assert_eq!(mount.source, tmp.to_string_lossy());
-        assert_eq!(mount.target.as_deref(), Some("/redan/host-claude-config"));
-
-        // CLAUDE_CONFIG_DIR points to guest-only tmp dir, not the host workspace
+        // CLAUDE_CONFIG_DIR points to guest-only tmp dir
         assert_eq!(
             auto.config.env.get("CLAUDE_CONFIG_DIR").map(String::as_str),
             Some("/tmp/.claude")
         );
 
-        // Command copies credentials to guest-only dir before launching
-        let cmd = auto.config.command.as_deref().unwrap();
-        assert!(cmd.contains("cp /redan/host-claude-config/.credentials.json /tmp/.claude/"));
-        assert!(cmd.ends_with("claude --dangerously-skip-permissions"));
+        // Credentials staged into rootfs before boot (no mount, no runtime copy)
+        let (host_path, guest_dir, filename) = auto.stage_credentials.as_ref().unwrap();
+        assert_eq!(host_path, &creds);
+        assert_eq!(guest_dir, "/tmp/.claude");
+        assert_eq!(filename, ".credentials.json");
+
+        // No config-dir mount (credentials are pre-staged)
+        assert!(!auto.config.mount.contains_key("claude-code-config"));
 
         assert!(
             auto.config
@@ -490,7 +485,7 @@ mod tests {
                 .allow
                 .contains(&"auth.anthropic.com".to_string())
         );
-        assert!(auto.messages.iter().any(|m| m.contains("read-only")));
+        assert!(auto.messages.iter().any(|m| m.contains("Staging")));
 
         let _ = std::fs::remove_dir_all(&tmp);
     }

--- a/src/auto_detect.rs
+++ b/src/auto_detect.rs
@@ -35,7 +35,8 @@ static CLAUDE_CODE: AgentDef = AgentDef {
     ],
     interactive: true,
     timeout_secs: 3600,
-    guest_env: &[],
+    run_as: Some("dev"),
+    guest_env: &[("HOME", "/home/dev")],
     api_key: Some(ApiKeyDef {
         env_var: "ANTHROPIC_API_KEY",
         inject_hosts: &["api.anthropic.com"],
@@ -68,6 +69,9 @@ pub struct AgentDef {
     pub hosts: &'static [&'static str],
     pub interactive: bool,
     pub timeout_secs: u64,
+    /// Run the user command as this OS user (via `runuser`).
+    /// None means run as root (libkrun default).
+    pub run_as: Option<&'static str>,
     /// Extra guest env vars (set regardless of auth method).
     pub guest_env: &'static [(&'static str, &'static str)],
     /// API-key-based auth (tried first).
@@ -115,6 +119,8 @@ pub struct AutoDetected {
     pub messages: Vec<String>,
     /// Whether the agent's image needs to be built first.
     pub needs_image_build: bool,
+    /// Run the user command as this OS user (via `runuser`).
+    pub run_as: Option<&'static str>,
 }
 
 /// A detected agent with its resolved auth method.
@@ -334,6 +340,7 @@ fn build_config(detected: &DetectedAgent) -> AutoDetected {
         config,
         messages,
         needs_image_build,
+        run_as: agent.run_as,
     }
 }
 
@@ -406,6 +413,11 @@ mod tests {
         assert_eq!(auto.config.image.as_deref(), Some("claude-code"));
         assert!(auto.config.command.as_deref().unwrap().contains("claude"));
         assert_eq!(auto.config.interactive, Some(true));
+        assert_eq!(auto.run_as, Some("dev"));
+        assert_eq!(
+            auto.config.env.get("HOME").map(String::as_str),
+            Some("/home/dev")
+        );
 
         let secret = auto.config.secrets.get("ANTHROPIC_API_KEY").unwrap();
         assert_eq!(secret.value, "env://ANTHROPIC_API_KEY");

--- a/src/auto_detect.rs
+++ b/src/auto_detect.rs
@@ -201,7 +201,7 @@ pub fn detect_all() -> Vec<DetectedAgent> {
 pub struct ExecFlags<'a> {
     pub image: &'a Option<String>,
     pub rootfs: &'a Option<String>,
-    pub command: &'a [String],
+    pub command: &'a Option<String>,
     pub secrets: &'a [String],
     pub secret_file: &'a Option<String>,
     pub mounts: &'a [String],
@@ -211,7 +211,7 @@ pub struct ExecFlags<'a> {
 pub const fn has_explicit_flags(f: &ExecFlags<'_>) -> bool {
     f.image.is_some()
         || f.rootfs.is_some()
-        || !f.command.is_empty()
+        || f.command.is_some()
         || !f.secrets.is_empty()
         || f.secret_file.is_some()
         || !f.mounts.is_empty()
@@ -651,7 +651,7 @@ mod tests {
         ExecFlags {
             image: &None,
             rootfs: &None,
-            command: &[],
+            command: &None,
             secrets: &[],
             secret_file: &None,
             mounts: &[],
@@ -675,7 +675,7 @@ mod tests {
 
     #[test]
     fn explicit_flags_detects_command() {
-        let cmd = vec!["echo".into(), "hello".into()];
+        let cmd = Some("echo hello".into());
         assert!(has_explicit_flags(&ExecFlags {
             command: &cmd,
             ..empty_flags()

--- a/src/browser.rs
+++ b/src/browser.rs
@@ -13,6 +13,7 @@ use std::io::{Read, Write};
 use std::net::{SocketAddr, SocketAddrV4, TcpListener, TcpStream, ToSocketAddrs};
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::thread::JoinHandle;
 use std::time::Duration;
@@ -21,6 +22,27 @@ use crate::proxy::host_matches;
 use crate::tls::is_private_ip;
 
 pub const CDP_PORT: u16 = 9222;
+
+/// Chrome PID for the atexit handler. `krun_start_enter` calls `exit()`,
+/// bypassing Rust Drop impls. Without this, Chrome is orphaned.
+static BROWSER_PID: Mutex<Option<u32>> = Mutex::new(None);
+
+extern "C" fn cleanup_browser_atexit() {
+    if let Ok(mut guard) = BROWSER_PID.lock()
+        && let Some(pid) = guard.take()
+    {
+        let pid = pid.cast_signed();
+        unsafe {
+            libc::kill(pid, libc::SIGTERM);
+            let mut status: i32 = 0;
+            libc::usleep(200_000);
+            if libc::waitpid(pid, &raw mut status, libc::WNOHANG) == 0 {
+                libc::kill(pid, libc::SIGKILL);
+                libc::waitpid(pid, &raw mut status, 0);
+            }
+        }
+    }
+}
 
 const CHROME_CANDIDATES: &[&str] = &[
     "chromium",
@@ -151,7 +173,15 @@ impl Browser {
             return Err(msg);
         }
 
-        log::info!("Chrome launched (pid {}, proxy :{proxy_port})", child.id());
+        let pid = child.id();
+        log::info!("Chrome launched (pid {pid}, proxy :{proxy_port})");
+
+        if let Ok(mut guard) = BROWSER_PID.lock() {
+            if guard.is_none() {
+                unsafe { libc::atexit(cleanup_browser_atexit) };
+            }
+            *guard = Some(pid);
+        }
 
         Ok(Self {
             child,
@@ -169,6 +199,11 @@ impl Browser {
 
 impl Drop for Browser {
     fn drop(&mut self) {
+        // Clear atexit PID so cleanup_browser_atexit doesn't double-kill.
+        if let Ok(mut guard) = BROWSER_PID.lock() {
+            *guard = None;
+        }
+
         self.proxy_shutdown.store(true, Ordering::Relaxed);
 
         let pid = self.child.id();

--- a/src/browser.rs
+++ b/src/browser.rs
@@ -1,0 +1,698 @@
+//! Headless Chrome lifecycle and CDP allowlist proxy.
+//!
+//! Chrome runs on the host (not in the VM). The agent in the VM connects
+//! to Chrome via CDP port forwarding. To prevent CDP from becoming a
+//! network escape hatch, redan launches Chrome with `--proxy-server`
+//! pointing to a lightweight HTTP CONNECT proxy that enforces the same
+//! host allowlist as the main MITM proxy.
+//!
+//! SECURITY: Chrome's sandbox MUST stay enabled. The VM isolates the
+//! agent, but Chrome runs on the host.
+
+use std::io::{Read, Write};
+use std::net::{SocketAddr, SocketAddrV4, TcpListener, TcpStream, ToSocketAddrs};
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread::JoinHandle;
+use std::time::Duration;
+
+use crate::proxy::host_matches;
+use crate::tls::is_private_ip;
+
+pub const CDP_PORT: u16 = 9222;
+
+const CHROME_CANDIDATES: &[&str] = &[
+    "chromium",
+    "chromium-browser",
+    "google-chrome-stable",
+    "google-chrome",
+];
+
+/// Find a Chrome/Chromium binary on PATH.
+pub fn find_chrome() -> Option<PathBuf> {
+    let path_var = std::env::var("PATH").ok()?;
+    for candidate in CHROME_CANDIDATES {
+        for dir in path_var.split(':') {
+            let full = PathBuf::from(dir).join(candidate);
+            if full.is_file() {
+                return Some(full);
+            }
+        }
+    }
+    None
+}
+
+pub struct BrowserConfig {
+    pub allowed_hosts: Option<Vec<String>>,
+}
+
+pub struct Browser {
+    child: std::process::Child,
+    profile_dir: PathBuf,
+    proxy_shutdown: Arc<AtomicBool>,
+    proxy_thread: Option<JoinHandle<()>>,
+    proxy_port: u16,
+}
+
+impl Browser {
+    pub fn launch(config: BrowserConfig) -> Result<Self, String> {
+        let chrome = find_chrome()
+            .ok_or("no Chrome/Chromium binary found on PATH. Install chromium or google-chrome.")?;
+
+        // Check CDP port is free (bind and immediately drop)
+        TcpListener::bind(("127.0.0.1", CDP_PORT)).map_err(|_| {
+            format!("port {CDP_PORT} is already in use. Stop the existing Chrome/CDP process.")
+        })?;
+
+        // Random profile directory
+        let mut rng_buf = [0u8; 4];
+        getrandom::fill(&mut rng_buf)
+            .map_err(|e| format!("failed to generate random bytes: {e}"))?;
+        let hex = rng_buf.map(|b| format!("{b:02x}")).join("");
+        let profile_dir = std::env::temp_dir().join(format!("redan-chrome-{hex}"));
+        std::fs::create_dir_all(&profile_dir)
+            .map_err(|e| format!("failed to create profile dir: {e}"))?;
+
+        // Bind the allowlist proxy
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .map_err(|e| format!("failed to bind allowlist proxy: {e}"))?;
+        let proxy_port = listener
+            .local_addr()
+            .map_err(|e| format!("failed to get proxy address: {e}"))?
+            .port();
+
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let shutdown_clone = shutdown.clone();
+        let allowed_hosts: Option<Arc<[String]>> = config.allowed_hosts.map(Into::into);
+
+        listener
+            .set_nonblocking(true)
+            .map_err(|e| format!("failed to set listener non-blocking: {e}"))?;
+
+        let proxy_thread = std::thread::Builder::new()
+            .name("browser-proxy".into())
+            .spawn(move || run_allowlist_proxy(listener, allowed_hosts, shutdown_clone))
+            .map_err(|e| format!("failed to spawn proxy thread: {e}"))?;
+
+        let mut child = std::process::Command::new(&chrome)
+            .args([
+                "--headless=new",
+                &format!("--remote-debugging-port={CDP_PORT}"),
+                "--remote-debugging-address=127.0.0.1",
+                &format!("--user-data-dir={}", profile_dir.display()),
+                "--no-first-run",
+                "--disable-extensions",
+                "--disable-sync",
+                "--disable-background-networking",
+                &format!("--proxy-server=http://127.0.0.1:{proxy_port}"),
+                "--proxy-bypass-list=<-loopback>",
+                "about:blank",
+            ])
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .map_err(|e| format!("failed to launch Chrome at {}: {e}", chrome.display()))?;
+
+        if !poll_cdp_ready(10) {
+            if let Some(status) = child.try_wait().ok().flatten() {
+                let mut stderr_buf = String::new();
+                if let Some(ref mut pipe) = child.stderr {
+                    let _ = pipe.read_to_string(&mut stderr_buf);
+                }
+                shutdown.store(true, Ordering::Relaxed);
+                let _ = std::fs::remove_dir_all(&profile_dir);
+                return Err(if stderr_buf.is_empty() {
+                    format!("Chrome exited with {status} before CDP was ready")
+                } else {
+                    format!("Chrome exited with {status}: {}", stderr_buf.trim())
+                });
+            }
+            shutdown.store(true, Ordering::Relaxed);
+            let _ = child.kill();
+            let _ = child.wait();
+            let _ = std::fs::remove_dir_all(&profile_dir);
+            return Err("Chrome started but CDP endpoint did not respond within 10s".into());
+        }
+
+        log::info!("Chrome launched (pid {}, proxy :{proxy_port})", child.id());
+
+        Ok(Self {
+            child,
+            profile_dir,
+            proxy_shutdown: shutdown,
+            proxy_thread: Some(proxy_thread),
+            proxy_port,
+        })
+    }
+
+    pub const fn proxy_port(&self) -> u16 {
+        self.proxy_port
+    }
+}
+
+impl Drop for Browser {
+    fn drop(&mut self) {
+        self.proxy_shutdown.store(true, Ordering::Relaxed);
+
+        let pid = self.child.id();
+        unsafe {
+            libc::kill(pid.cast_signed(), libc::SIGTERM);
+        }
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        loop {
+            if self.child.try_wait().ok().flatten().is_some() {
+                break;
+            }
+            if std::time::Instant::now() >= deadline {
+                let _ = self.child.kill();
+                let _ = self.child.wait();
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+
+        if let Some(t) = self.proxy_thread.take() {
+            let _ = t.join();
+        }
+
+        let _ = std::fs::remove_dir_all(&self.profile_dir);
+        log::info!("Chrome stopped and profile cleaned up");
+    }
+}
+
+fn poll_cdp_ready(timeout_secs: u64) -> bool {
+    let deadline = std::time::Instant::now() + Duration::from_secs(timeout_secs);
+    let url = format!("http://127.0.0.1:{CDP_PORT}/json/version");
+
+    while std::time::Instant::now() < deadline {
+        if let Ok(mut resp) = ureq::get(&url).call()
+            && resp.status() == 200
+        {
+            let _ = resp.body_mut().read_to_string();
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+    false
+}
+
+// ---------------------------------------------------------------------------
+// Allowlist proxy
+// ---------------------------------------------------------------------------
+
+#[allow(clippy::needless_pass_by_value)] // Owned values needed: moved into thread
+fn run_allowlist_proxy(
+    listener: TcpListener,
+    allowed_hosts: Option<Arc<[String]>>,
+    shutdown: Arc<AtomicBool>,
+) {
+    while !shutdown.load(Ordering::Relaxed) {
+        match listener.accept() {
+            Ok((stream, _)) => {
+                let hosts = allowed_hosts.clone();
+                let _ = std::thread::Builder::new()
+                    .name("browser-proxy-conn".into())
+                    .spawn(move || handle_proxy_connection(stream, hosts.as_deref()));
+            }
+            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            Err(_) => break,
+        }
+    }
+}
+
+fn handle_proxy_connection(mut client: TcpStream, allowed_hosts: Option<&[String]>) {
+    let _ = client.set_read_timeout(Some(Duration::from_secs(30)));
+
+    let mut buf = [0u8; 8192];
+    let mut filled = 0;
+
+    loop {
+        if filled >= buf.len() {
+            let _ = client.write_all(b"HTTP/1.1 431 Request Header Fields Too Large\r\n\r\n");
+            return;
+        }
+        match client.read(&mut buf[filled..]) {
+            Ok(0) | Err(_) => return,
+            Ok(n) => {
+                filled += n;
+                if crate::secret::find_header_end(&buf[..filled]).is_some() {
+                    break;
+                }
+            }
+        }
+    }
+
+    let line_end = buf[..filled]
+        .windows(2)
+        .position(|w| w == b"\r\n")
+        .unwrap_or(filled);
+
+    let Ok(request_line) = std::str::from_utf8(&buf[..line_end]) else {
+        let _ = client.write_all(b"HTTP/1.1 400 Bad Request\r\n\r\n");
+        return;
+    };
+
+    let mut parts = request_line.splitn(3, ' ');
+    let method = parts.next().unwrap_or("");
+    let target = parts.next().unwrap_or("");
+
+    if method.eq_ignore_ascii_case("CONNECT") {
+        handle_connect(client, target, allowed_hosts);
+    } else {
+        handle_forward_http(client, &buf[..filled], method, target, allowed_hosts);
+    }
+}
+
+fn handle_connect(mut client: TcpStream, target: &str, allowed_hosts: Option<&[String]>) {
+    let Some((host, port)) = parse_connect_target(target) else {
+        let _ = client.write_all(b"HTTP/1.1 400 Bad Request\r\n\r\n");
+        return;
+    };
+
+    if !is_host_allowed(host, allowed_hosts) {
+        log::info!("browser proxy: blocked CONNECT to {host}:{port} (not in allowlist)");
+        let _ = client.write_all(b"HTTP/1.1 403 Forbidden\r\nConnection: close\r\n\r\n");
+        return;
+    }
+
+    let upstream = match resolve_and_connect(host, port) {
+        Ok(s) => s,
+        Err(msg) => {
+            log::warn!("browser proxy: {msg}");
+            let _ = client.write_all(b"HTTP/1.1 502 Bad Gateway\r\nConnection: close\r\n\r\n");
+            return;
+        }
+    };
+
+    if client
+        .write_all(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+        .is_err()
+    {
+        return;
+    }
+
+    relay_bidirectional(client, upstream);
+}
+
+fn handle_forward_http(
+    mut client: TcpStream,
+    header_data: &[u8],
+    method: &str,
+    target: &str,
+    allowed_hosts: Option<&[String]>,
+) {
+    let Some((host, port, path)) = parse_absolute_uri(target) else {
+        let _ = client.write_all(b"HTTP/1.1 400 Bad Request\r\n\r\n");
+        return;
+    };
+
+    if !is_host_allowed(&host, allowed_hosts) {
+        log::info!("browser proxy: blocked HTTP {method} to {host} (not in allowlist)");
+        let _ = client.write_all(b"HTTP/1.1 403 Forbidden\r\nConnection: close\r\n\r\n");
+        return;
+    }
+
+    let mut upstream = match resolve_and_connect(&host, port) {
+        Ok(s) => s,
+        Err(msg) => {
+            log::warn!("browser proxy: {msg}");
+            let _ = client.write_all(b"HTTP/1.1 502 Bad Gateway\r\nConnection: close\r\n\r\n");
+            return;
+        }
+    };
+
+    // Rewrite the request line to use the relative path
+    let line_end = header_data
+        .windows(2)
+        .position(|w| w == b"\r\n")
+        .unwrap_or(header_data.len());
+
+    let version_str = std::str::from_utf8(&header_data[..line_end])
+        .ok()
+        .and_then(|line| line.rsplit(' ').next())
+        .unwrap_or("HTTP/1.1");
+
+    let rewritten_line = format!("{method} {path} {version_str}\r\n");
+    if upstream.write_all(rewritten_line.as_bytes()).is_err() {
+        return;
+    }
+
+    // Forward remaining headers (everything after the first line)
+    let after_first_line = line_end + 2; // skip past \r\n
+    if after_first_line < header_data.len()
+        && upstream
+            .write_all(&header_data[after_first_line..])
+            .is_err()
+    {
+        return;
+    }
+
+    // Relay remaining body + response
+    relay_bidirectional(client, upstream);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn is_host_allowed(host: &str, allowed_hosts: Option<&[String]>) -> bool {
+    let Some(hosts) = allowed_hosts else {
+        return true;
+    };
+    hosts.iter().any(|pattern| host_matches(pattern, host))
+}
+
+/// Resolve a hostname to IPv4 addresses, check for SSRF, and connect.
+/// Only uses IPv4 to match the main proxy's behavior.
+fn resolve_and_connect(host: &str, port: u16) -> Result<TcpStream, String> {
+    let addrs: Vec<SocketAddrV4> = (host, port)
+        .to_socket_addrs()
+        .map_err(|e| format!("DNS resolution failed for {host}: {e}"))?
+        .filter_map(|addr| match addr {
+            SocketAddr::V4(v4) => Some(v4),
+            SocketAddr::V6(_) => None,
+        })
+        .collect();
+
+    if addrs.is_empty() {
+        return Err(format!("no IPv4 addresses found for {host}"));
+    }
+
+    for addr in &addrs {
+        if is_private_ip(*addr.ip()) {
+            return Err(format!(
+                "{host} resolves to private IP {addr} (SSRF blocked)"
+            ));
+        }
+    }
+
+    let sock_addrs: Vec<SocketAddr> = addrs.into_iter().map(SocketAddr::V4).collect();
+    TcpStream::connect(&sock_addrs[..])
+        .map_err(|e| format!("connection to {host}:{port} failed: {e}"))
+}
+
+fn relay_bidirectional(a: TcpStream, b: TcpStream) {
+    let Ok(a_clone) = a.try_clone() else { return };
+    let Ok(b_clone) = b.try_clone() else { return };
+
+    // a -> b (spawned thread)
+    let t = std::thread::spawn(move || {
+        let mut reader = a_clone;
+        let mut writer = b_clone;
+        let mut buf = [0u8; 8192];
+        loop {
+            match reader.read(&mut buf) {
+                Ok(0) | Err(_) => break,
+                Ok(n) => {
+                    if writer.write_all(&buf[..n]).is_err() {
+                        break;
+                    }
+                }
+            }
+        }
+        let _ = writer.shutdown(std::net::Shutdown::Write);
+    });
+
+    // b -> a (this thread)
+    let mut reader = b;
+    let mut writer = a;
+    let mut buf = [0u8; 8192];
+    loop {
+        match reader.read(&mut buf) {
+            Ok(0) | Err(_) => break,
+            Ok(n) => {
+                if writer.write_all(&buf[..n]).is_err() {
+                    break;
+                }
+            }
+        }
+    }
+    let _ = writer.shutdown(std::net::Shutdown::Write);
+    let _ = t.join();
+}
+
+fn parse_connect_target(target: &str) -> Option<(&str, u16)> {
+    let (host, port_str) = target.rsplit_once(':')?;
+    if host.is_empty() {
+        return None;
+    }
+    let port: u16 = port_str.parse().ok()?;
+    Some((host, port))
+}
+
+fn parse_absolute_uri(uri: &str) -> Option<(String, u16, String)> {
+    let rest = uri.strip_prefix("http://")?;
+    let (authority, path) = rest
+        .split_once('/')
+        .map_or_else(|| (rest, "/".to_string()), |(a, p)| (a, format!("/{p}")));
+    let (host, port) = match authority.rsplit_once(':') {
+        Some((h, p)) => (h, p.parse().ok()?),
+        None => (authority, 80),
+    };
+    if host.is_empty() {
+        return None;
+    }
+    Some((host.to_string(), port, path))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    // -- parse_connect_target -------------------------------------------------
+
+    #[test]
+    fn parse_connect_target_valid() {
+        assert_eq!(
+            parse_connect_target("example.com:443"),
+            Some(("example.com", 443))
+        );
+    }
+
+    #[test]
+    fn parse_connect_target_custom_port() {
+        assert_eq!(
+            parse_connect_target("cdn.example.com:8443"),
+            Some(("cdn.example.com", 8443))
+        );
+    }
+
+    #[test]
+    fn parse_connect_target_no_port() {
+        assert_eq!(parse_connect_target("example.com"), None);
+    }
+
+    #[test]
+    fn parse_connect_target_empty_host() {
+        assert_eq!(parse_connect_target(":443"), None);
+    }
+
+    #[test]
+    fn parse_connect_target_invalid_port() {
+        assert_eq!(parse_connect_target("example.com:notaport"), None);
+    }
+
+    #[test]
+    fn parse_connect_target_port_overflow() {
+        assert_eq!(parse_connect_target("example.com:99999"), None);
+    }
+
+    // -- parse_absolute_uri ---------------------------------------------------
+
+    #[test]
+    fn parse_absolute_uri_with_port() {
+        let (host, port, path) = parse_absolute_uri("http://example.com:8080/path").unwrap();
+        assert_eq!(host, "example.com");
+        assert_eq!(port, 8080);
+        assert_eq!(path, "/path");
+    }
+
+    #[test]
+    fn parse_absolute_uri_default_port() {
+        let (host, port, path) = parse_absolute_uri("http://example.com/index.html").unwrap();
+        assert_eq!(host, "example.com");
+        assert_eq!(port, 80);
+        assert_eq!(path, "/index.html");
+    }
+
+    #[test]
+    fn parse_absolute_uri_no_path() {
+        let (host, port, path) = parse_absolute_uri("http://example.com").unwrap();
+        assert_eq!(host, "example.com");
+        assert_eq!(port, 80);
+        assert_eq!(path, "/");
+    }
+
+    #[test]
+    fn parse_absolute_uri_rejects_https() {
+        assert!(parse_absolute_uri("https://example.com/path").is_none());
+    }
+
+    #[test]
+    fn parse_absolute_uri_rejects_relative() {
+        assert!(parse_absolute_uri("/just/a/path").is_none());
+    }
+
+    // -- is_host_allowed ------------------------------------------------------
+
+    #[test]
+    fn host_allowed_when_no_restriction() {
+        assert!(is_host_allowed("anything.com", None));
+    }
+
+    #[test]
+    fn host_allowed_when_in_list() {
+        let hosts = vec!["api.example.com".into(), "cdn.example.com".into()];
+        assert!(is_host_allowed("api.example.com", Some(&hosts)));
+    }
+
+    #[test]
+    fn host_blocked_when_not_in_list() {
+        let hosts = vec!["api.example.com".into()];
+        assert!(!is_host_allowed("evil.com", Some(&hosts)));
+    }
+
+    #[test]
+    fn host_allowed_with_wildcard_pattern() {
+        let hosts = vec!["*.example.com".into()];
+        assert!(is_host_allowed("api.example.com", Some(&hosts)));
+        assert!(!is_host_allowed("example.com", Some(&hosts)));
+    }
+
+    #[test]
+    fn host_blocked_when_list_empty() {
+        let hosts: Vec<String> = vec![];
+        assert!(!is_host_allowed("anything.com", Some(&hosts)));
+    }
+
+    // -- find_chrome ----------------------------------------------------------
+
+    #[test]
+    fn find_chrome_empty_path_returns_none() {
+        let original = std::env::var("PATH").ok();
+        unsafe { std::env::set_var("PATH", "") };
+        let result = find_chrome();
+        if let Some(p) = original {
+            unsafe { std::env::set_var("PATH", p) };
+        }
+        assert!(result.is_none());
+    }
+
+    // -- allowlist proxy integration ------------------------------------------
+
+    #[test]
+    fn proxy_blocks_non_allowlisted_connect() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let proxy_port = listener.local_addr().unwrap().port();
+
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let shutdown_clone = shutdown.clone();
+        let hosts: Option<Arc<[String]>> = Some(vec!["allowed.example.com".into()].into());
+
+        listener.set_nonblocking(true).unwrap();
+        let proxy = std::thread::spawn(move || {
+            run_allowlist_proxy(listener, hosts, shutdown_clone);
+        });
+
+        // Give the proxy a moment to start
+        std::thread::sleep(Duration::from_millis(50));
+
+        let mut client = TcpStream::connect(("127.0.0.1", proxy_port)).unwrap();
+        client
+            .write_all(b"CONNECT blocked.example.com:443 HTTP/1.1\r\nHost: blocked.example.com:443\r\n\r\n")
+            .unwrap();
+
+        let mut response = vec![0u8; 4096];
+        let n = client.read(&mut response).unwrap();
+        let response_str = std::str::from_utf8(&response[..n]).unwrap();
+
+        assert!(
+            response_str.contains("403"),
+            "expected 403 for blocked host, got: {response_str}"
+        );
+
+        shutdown.store(true, Ordering::Relaxed);
+        let _ = proxy.join();
+    }
+
+    #[test]
+    fn proxy_blocks_forward_http_non_allowlisted() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let proxy_port = listener.local_addr().unwrap().port();
+
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let shutdown_clone = shutdown.clone();
+        let hosts: Option<Arc<[String]>> = Some(vec!["allowed.example.com".into()].into());
+
+        listener.set_nonblocking(true).unwrap();
+        let proxy = std::thread::spawn(move || {
+            run_allowlist_proxy(listener, hosts, shutdown_clone);
+        });
+
+        std::thread::sleep(Duration::from_millis(50));
+
+        let mut client = TcpStream::connect(("127.0.0.1", proxy_port)).unwrap();
+        client
+            .write_all(b"GET http://blocked.example.com/path HTTP/1.1\r\nHost: blocked.example.com\r\n\r\n")
+            .unwrap();
+
+        let mut response = vec![0u8; 4096];
+        let n = client.read(&mut response).unwrap();
+        let response_str = std::str::from_utf8(&response[..n]).unwrap();
+
+        assert!(
+            response_str.contains("403"),
+            "expected 403 for blocked host, got: {response_str}"
+        );
+
+        shutdown.store(true, Ordering::Relaxed);
+        let _ = proxy.join();
+    }
+
+    #[test]
+    fn proxy_connect_ssrf_blocks_private_ip() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let proxy_port = listener.local_addr().unwrap().port();
+
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let shutdown_clone = shutdown.clone();
+
+        listener.set_nonblocking(true).unwrap();
+        // allow-all mode (None), but SSRF check should still block localhost
+        let proxy = std::thread::spawn(move || {
+            run_allowlist_proxy(listener, None, shutdown_clone);
+        });
+
+        std::thread::sleep(Duration::from_millis(50));
+
+        let mut client = TcpStream::connect(("127.0.0.1", proxy_port)).unwrap();
+        client
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .unwrap();
+        client
+            .write_all(b"CONNECT 127.0.0.1:80 HTTP/1.1\r\nHost: 127.0.0.1:80\r\n\r\n")
+            .unwrap();
+
+        let mut response = vec![0u8; 4096];
+        let n = client.read(&mut response).unwrap();
+        let response_str = std::str::from_utf8(&response[..n]).unwrap();
+
+        assert!(
+            response_str.contains("502"),
+            "expected 502 for SSRF-blocked IP, got: {response_str}"
+        );
+
+        shutdown.store(true, Ordering::Relaxed);
+        let _ = proxy.join();
+    }
+}

--- a/src/browser.rs
+++ b/src/browser.rs
@@ -31,14 +31,15 @@ extern "C" fn cleanup_browser_atexit() {
     if let Ok(mut guard) = BROWSER_PID.lock()
         && let Some(pid) = guard.take()
     {
-        let pid = pid.cast_signed();
+        // Negative PID = kill the entire process group (Chrome tree).
+        let pgid = -(pid.cast_signed());
         unsafe {
-            libc::kill(pid, libc::SIGTERM);
+            libc::kill(pgid, libc::SIGTERM);
             let mut status: i32 = 0;
-            libc::usleep(200_000);
-            if libc::waitpid(pid, &raw mut status, libc::WNOHANG) == 0 {
-                libc::kill(pid, libc::SIGKILL);
-                libc::waitpid(pid, &raw mut status, 0);
+            libc::usleep(500_000);
+            if libc::waitpid(pid.cast_signed(), &raw mut status, libc::WNOHANG) == 0 {
+                libc::kill(pgid, libc::SIGKILL);
+                libc::waitpid(pid.cast_signed(), &raw mut status, 0);
             }
         }
     }
@@ -124,25 +125,7 @@ impl Browser {
 
         // From this point, any early return must tear down the proxy thread
         // and profile dir since Drop won't run on an unconstructed Self.
-        let mut child = match std::process::Command::new(&chrome)
-            .args([
-                "--headless=new",
-                &format!("--remote-debugging-port={CDP_PORT}"),
-                "--remote-debugging-address=127.0.0.1",
-                &format!("--user-data-dir={}", profile_dir.display()),
-                "--no-first-run",
-                "--disable-extensions",
-                "--disable-sync",
-                "--disable-background-networking",
-                &format!("--proxy-server=http://127.0.0.1:{proxy_port}"),
-                "--proxy-bypass-list=<-loopback>",
-                "about:blank",
-            ])
-            .stdin(std::process::Stdio::null())
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::piped())
-            .spawn()
-        {
+        let mut child = match spawn_chrome(&chrome, &profile_dir, proxy_port) {
             Ok(child) => child,
             Err(e) => {
                 cleanup_proxy(&shutdown, proxy_thread, &profile_dir);
@@ -206,9 +189,10 @@ impl Drop for Browser {
 
         self.proxy_shutdown.store(true, Ordering::Relaxed);
 
-        let pid = self.child.id();
+        // Kill the entire process group (Chrome tree: zygotes, GPU, renderers).
+        let pgid = self.child.id().cast_signed();
         unsafe {
-            libc::kill(pid.cast_signed(), libc::SIGTERM);
+            libc::kill(-pgid, libc::SIGTERM);
         }
 
         let deadline = std::time::Instant::now() + Duration::from_secs(2);
@@ -217,7 +201,7 @@ impl Drop for Browser {
                 break;
             }
             if std::time::Instant::now() >= deadline {
-                let _ = self.child.kill();
+                unsafe { libc::kill(-pgid, libc::SIGKILL) };
                 let _ = self.child.wait();
                 break;
             }
@@ -231,6 +215,42 @@ impl Drop for Browser {
         let _ = std::fs::remove_dir_all(&self.profile_dir);
         log::info!("Chrome stopped and profile cleaned up");
     }
+}
+
+fn spawn_chrome(
+    chrome: &std::path::Path,
+    profile_dir: &std::path::Path,
+    proxy_port: u16,
+) -> std::io::Result<std::process::Child> {
+    let mut cmd = std::process::Command::new(chrome);
+    cmd.args([
+        "--headless=new",
+        &format!("--remote-debugging-port={CDP_PORT}"),
+        "--remote-debugging-address=127.0.0.1",
+        &format!("--user-data-dir={}", profile_dir.display()),
+        "--no-first-run",
+        "--disable-extensions",
+        "--disable-sync",
+        "--disable-background-networking",
+        &format!("--proxy-server=http://127.0.0.1:{proxy_port}"),
+        "--proxy-bypass-list=<-loopback>",
+        "about:blank",
+    ])
+    .stdin(std::process::Stdio::null())
+    .stdout(std::process::Stdio::null())
+    .stderr(std::process::Stdio::piped());
+
+    // Own process group so kill(-pgid) reaches the entire Chrome tree
+    // (zygotes, GPU process, renderers, network service, etc).
+    unsafe {
+        use std::os::unix::process::CommandExt;
+        cmd.pre_exec(|| {
+            libc::setpgid(0, 0);
+            Ok(())
+        });
+    }
+
+    cmd.spawn()
 }
 
 fn cleanup_proxy(shutdown: &AtomicBool, thread: JoinHandle<()>, profile_dir: &std::path::Path) {

--- a/src/browser.rs
+++ b/src/browser.rs
@@ -13,7 +13,6 @@ use std::io::{Read, Write};
 use std::net::{SocketAddr, SocketAddrV4, TcpListener, TcpStream, ToSocketAddrs};
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::thread::JoinHandle;
 use std::time::Duration;
@@ -22,28 +21,6 @@ use crate::proxy::host_matches;
 use crate::tls::is_private_ip;
 
 pub const CDP_PORT: u16 = 9222;
-
-/// Chrome PID for the atexit handler. `krun_start_enter` calls `exit()`,
-/// bypassing Rust Drop impls. Without this, Chrome is orphaned.
-static BROWSER_PID: Mutex<Option<u32>> = Mutex::new(None);
-
-extern "C" fn cleanup_browser_atexit() {
-    if let Ok(mut guard) = BROWSER_PID.lock()
-        && let Some(pid) = guard.take()
-    {
-        // Negative PID = kill the entire process group (Chrome tree).
-        let pgid = -(pid.cast_signed());
-        unsafe {
-            libc::kill(pgid, libc::SIGTERM);
-            let mut status: i32 = 0;
-            libc::usleep(500_000);
-            if libc::waitpid(pid.cast_signed(), &raw mut status, libc::WNOHANG) == 0 {
-                libc::kill(pgid, libc::SIGKILL);
-                libc::waitpid(pid.cast_signed(), &raw mut status, 0);
-            }
-        }
-    }
-}
 
 const CHROME_CANDIDATES: &[&str] = &[
     "chromium",
@@ -156,15 +133,7 @@ impl Browser {
             return Err(msg);
         }
 
-        let pid = child.id();
-        log::info!("Chrome launched (pid {pid}, proxy :{proxy_port})");
-
-        if let Ok(mut guard) = BROWSER_PID.lock() {
-            if guard.is_none() {
-                unsafe { libc::atexit(cleanup_browser_atexit) };
-            }
-            *guard = Some(pid);
-        }
+        log::info!("Chrome launched (pid {}, proxy :{proxy_port})", child.id());
 
         Ok(Self {
             child,
@@ -182,11 +151,6 @@ impl Browser {
 
 impl Drop for Browser {
     fn drop(&mut self) {
-        // Clear atexit PID so cleanup_browser_atexit doesn't double-kill.
-        if let Ok(mut guard) = BROWSER_PID.lock() {
-            *guard = None;
-        }
-
         self.proxy_shutdown.store(true, Ordering::Relaxed);
 
         // Kill the entire process group (Chrome tree: zygotes, GPU, renderers).
@@ -242,10 +206,14 @@ fn spawn_chrome(
 
     // Own process group so kill(-pgid) reaches the entire Chrome tree
     // (zygotes, GPU process, renderers, network service, etc).
+    // PDEATHSIG is kernel-enforced cleanup for paths no userspace
+    // handler covers (redan SIGKILLed): Chrome gets SIGTERM and shuts
+    // its tree down itself.
     unsafe {
         use std::os::unix::process::CommandExt;
         cmd.pre_exec(|| {
             libc::setpgid(0, 0);
+            libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGTERM);
             Ok(())
         });
     }

--- a/src/browser.rs
+++ b/src/browser.rs
@@ -13,7 +13,7 @@ use std::io::{Read, Write};
 use std::net::{SocketAddr, SocketAddrV4, TcpListener, TcpStream, ToSocketAddrs};
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::thread::JoinHandle;
 use std::time::Duration;
 
@@ -71,8 +71,13 @@ impl Browser {
             .map_err(|e| format!("failed to generate random bytes: {e}"))?;
         let hex = rng_buf.map(|b| format!("{b:02x}")).join("");
         let profile_dir = std::env::temp_dir().join(format!("redan-chrome-{hex}"));
-        std::fs::create_dir_all(&profile_dir)
-            .map_err(|e| format!("failed to create profile dir: {e}"))?;
+        {
+            use std::os::unix::fs::DirBuilderExt;
+            std::fs::DirBuilder::new()
+                .mode(0o700)
+                .create(&profile_dir)
+                .map_err(|e| format!("failed to create profile dir: {e}"))?;
+        }
 
         // Bind the allowlist proxy
         let listener = TcpListener::bind("127.0.0.1:0")
@@ -95,7 +100,9 @@ impl Browser {
             .spawn(move || run_allowlist_proxy(listener, allowed_hosts, shutdown_clone))
             .map_err(|e| format!("failed to spawn proxy thread: {e}"))?;
 
-        let mut child = std::process::Command::new(&chrome)
+        // From this point, any early return must tear down the proxy thread
+        // and profile dir since Drop won't run on an unconstructed Self.
+        let mut child = match std::process::Command::new(&chrome)
             .args([
                 "--headless=new",
                 &format!("--remote-debugging-port={CDP_PORT}"),
@@ -113,27 +120,35 @@ impl Browser {
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::piped())
             .spawn()
-            .map_err(|e| format!("failed to launch Chrome at {}: {e}", chrome.display()))?;
+        {
+            Ok(child) => child,
+            Err(e) => {
+                cleanup_proxy(&shutdown, proxy_thread, &profile_dir);
+                return Err(format!(
+                    "failed to launch Chrome at {}: {e}",
+                    chrome.display()
+                ));
+            }
+        };
 
         if !poll_cdp_ready(10) {
-            if let Some(status) = child.try_wait().ok().flatten() {
+            let msg = if let Some(status) = child.try_wait().ok().flatten() {
                 let mut stderr_buf = String::new();
                 if let Some(ref mut pipe) = child.stderr {
                     let _ = pipe.read_to_string(&mut stderr_buf);
                 }
-                shutdown.store(true, Ordering::Relaxed);
-                let _ = std::fs::remove_dir_all(&profile_dir);
-                return Err(if stderr_buf.is_empty() {
+                if stderr_buf.is_empty() {
                     format!("Chrome exited with {status} before CDP was ready")
                 } else {
                     format!("Chrome exited with {status}: {}", stderr_buf.trim())
-                });
-            }
-            shutdown.store(true, Ordering::Relaxed);
-            let _ = child.kill();
-            let _ = child.wait();
-            let _ = std::fs::remove_dir_all(&profile_dir);
-            return Err("Chrome started but CDP endpoint did not respond within 10s".into());
+                }
+            } else {
+                let _ = child.kill();
+                let _ = child.wait();
+                "Chrome started but CDP endpoint did not respond within 10s".into()
+            };
+            cleanup_proxy(&shutdown, proxy_thread, &profile_dir);
+            return Err(msg);
         }
 
         log::info!("Chrome launched (pid {}, proxy :{proxy_port})", child.id());
@@ -183,6 +198,12 @@ impl Drop for Browser {
     }
 }
 
+fn cleanup_proxy(shutdown: &AtomicBool, thread: JoinHandle<()>, profile_dir: &std::path::Path) {
+    shutdown.store(true, Ordering::Relaxed);
+    let _ = thread.join();
+    let _ = std::fs::remove_dir_all(profile_dir);
+}
+
 fn poll_cdp_ready(timeout_secs: u64) -> bool {
     let deadline = std::time::Instant::now() + Duration::from_secs(timeout_secs);
     let url = format!("http://127.0.0.1:{CDP_PORT}/json/version");
@@ -203,19 +224,32 @@ fn poll_cdp_ready(timeout_secs: u64) -> bool {
 // Allowlist proxy
 // ---------------------------------------------------------------------------
 
+const MAX_PROXY_WORKERS: usize = 32;
+
 #[allow(clippy::needless_pass_by_value)] // Owned values needed: moved into thread
 fn run_allowlist_proxy(
     listener: TcpListener,
     allowed_hosts: Option<Arc<[String]>>,
     shutdown: Arc<AtomicBool>,
 ) {
+    let active = Arc::new(AtomicUsize::new(0));
+
     while !shutdown.load(Ordering::Relaxed) {
         match listener.accept() {
             Ok((stream, _)) => {
+                if active.load(Ordering::Relaxed) >= MAX_PROXY_WORKERS {
+                    drop(stream);
+                    continue;
+                }
                 let hosts = allowed_hosts.clone();
+                let active = active.clone();
+                active.fetch_add(1, Ordering::Relaxed);
                 let _ = std::thread::Builder::new()
                     .name("browser-proxy-conn".into())
-                    .spawn(move || handle_proxy_connection(stream, hosts.as_deref()));
+                    .spawn(move || {
+                        handle_proxy_connection(stream, hosts.as_deref());
+                        active.fetch_sub(1, Ordering::Relaxed);
+                    });
             }
             Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
                 std::thread::sleep(Duration::from_millis(50));
@@ -391,9 +425,14 @@ fn resolve_and_connect(host: &str, port: u16) -> Result<TcpStream, String> {
         }
     }
 
-    let sock_addrs: Vec<SocketAddr> = addrs.into_iter().map(SocketAddr::V4).collect();
-    TcpStream::connect(&sock_addrs[..])
-        .map_err(|e| format!("connection to {host}:{port} failed: {e}"))
+    let mut last_err = String::new();
+    for addr in addrs {
+        match TcpStream::connect_timeout(&SocketAddr::V4(addr), Duration::from_secs(10)) {
+            Ok(stream) => return Ok(stream),
+            Err(e) => last_err = e.to_string(),
+        }
+    }
+    Err(format!("connection to {host}:{port} failed: {last_err}"))
 }
 
 fn relay_bidirectional(a: TcpStream, b: TcpStream) {

--- a/src/cmd/doctor.rs
+++ b/src/cmd/doctor.rs
@@ -105,6 +105,13 @@ pub(crate) fn run(secret_specs: &[String], check_image: Option<&str>) {
         }
     }
 
+    // Chrome/Chromium (informational, not required)
+    if let Some(path) = redan::browser::find_chrome() {
+        println!("[ok]   chrome: {}", path.display());
+    } else {
+        println!("[info] chrome: not found (optional, needed for --browser)");
+    }
+
     // Validate secrets (never print values)
     for spec in secret_specs {
         let env_label = spec.split_once('=').map_or("(invalid)", |(name, _)| name);

--- a/src/cmd/exec.rs
+++ b/src/cmd/exec.rs
@@ -288,13 +288,24 @@ pub(crate) fn run(cfg: &ExecConfig<'_>) {
                     guest_port: redan::browser::CDP_PORT,
                     host_port: redan::browser::CDP_PORT,
                 };
-                if !forwards.iter().any(|f| f.guest_port == cdp_fwd.guest_port) {
-                    log::info!(
-                        "forward: :{} -> 127.0.0.1:{} (CDP)",
-                        cdp_fwd.guest_port,
-                        cdp_fwd.host_port
-                    );
-                    forwards.push(cdp_fwd);
+                match forwards.iter().find(|f| f.guest_port == cdp_fwd.guest_port) {
+                    Some(existing) if existing.host_port != cdp_fwd.host_port => {
+                        eprintln!(
+                            "error: --browser reserves guest port {} for Chrome CDP, \
+                             but it is already forwarded to host port {}",
+                            cdp_fwd.guest_port, existing.host_port
+                        );
+                        std::process::exit(1);
+                    }
+                    Some(_) => {}
+                    None => {
+                        log::info!(
+                            "forward: :{} -> 127.0.0.1:{} (CDP)",
+                            cdp_fwd.guest_port,
+                            cdp_fwd.host_port
+                        );
+                        forwards.push(cdp_fwd);
+                    }
                 }
                 Some(b)
             }

--- a/src/cmd/exec.rs
+++ b/src/cmd/exec.rs
@@ -27,6 +27,8 @@ pub(crate) struct ExecConfig<'a> {
     pub session_id: Option<&'a str>,
     /// Run the user command as this OS user (via `runuser`).
     pub run_as: Option<&'a str>,
+    /// Launch headless Chrome with CDP and an allowlist proxy.
+    pub browser: bool,
 }
 
 pub(crate) fn run(cfg: &ExecConfig<'_>) {
@@ -211,6 +213,15 @@ pub(crate) fn run(cfg: &ExecConfig<'_>) {
         env.push(format!("{name}={value}"));
     }
 
+    if cfg.browser {
+        env.push("REDAN_BROWSER=1".into());
+        env.push(format!("REDAN_BROWSER_HOST={}", proxy::GATEWAY_IP));
+        env.push(format!(
+            "REDAN_BROWSER_CDP_PORT={}",
+            redan::browser::CDP_PORT
+        ));
+    }
+
     let vm_config = vm::VmConfig {
         rootfs: cfg.rootfs.into(),
         vcpus: 1,
@@ -265,6 +276,36 @@ pub(crate) fn run(cfg: &ExecConfig<'_>) {
             }
         }
     }
+
+    // Launch headless Chrome if requested. Held until proxy::run returns.
+    let _browser = if cfg.browser {
+        match redan::browser::Browser::launch(redan::browser::BrowserConfig {
+            allowed_hosts: allowed_hosts.clone(),
+        }) {
+            Ok(b) => {
+                // Add CDP forward so the guest can reach Chrome
+                let cdp_fwd = proxy::ForwardSpec {
+                    guest_port: redan::browser::CDP_PORT,
+                    host_port: redan::browser::CDP_PORT,
+                };
+                if !forwards.iter().any(|f| f.guest_port == cdp_fwd.guest_port) {
+                    log::info!(
+                        "forward: :{} -> 127.0.0.1:{} (CDP)",
+                        cdp_fwd.guest_port,
+                        cdp_fwd.host_port
+                    );
+                    forwards.push(cdp_fwd);
+                }
+                Some(b)
+            }
+            Err(e) => {
+                eprintln!("error: failed to launch browser: {e}");
+                std::process::exit(1);
+            }
+        }
+    } else {
+        None
+    };
 
     let discovered = proxy::run(proxy::ProxyConfig {
         host_sock: net_sock,

--- a/src/cmd/exec.rs
+++ b/src/cmd/exec.rs
@@ -470,12 +470,15 @@ pub(crate) fn parse_mount(spec: &str) -> (String, String, bool) {
 
 /// Shell command that creates the target user if it doesn't exist.
 /// Runs as root in the init script, before `runuser` drops privileges.
-/// Handles both Alpine (adduser) and Debian/Ubuntu (useradd).
+/// Tries useradd (shadow-utils), Debian adduser, then Alpine/BusyBox
+/// adduser. Stderr suppressed so failed attempts don't spew into the
+/// terminal.
 fn ensure_user_command(user: &str) -> String {
     format!(
         "id -u {user} >/dev/null 2>&1 || \
-         {{ command -v adduser >/dev/null 2>&1 && adduser -D -h /home/{user} {user} || \
-         useradd -m -s /bin/sh {user}; }}"
+         useradd -m -s /bin/sh {user} 2>/dev/null || \
+         adduser --disabled-password --gecos '' {user} 2>/dev/null || \
+         adduser -D -h /home/{user} {user} 2>/dev/null"
     )
 }
 
@@ -634,8 +637,10 @@ mod tests {
     fn ensure_user_command_creates_user() {
         let cmd = ensure_user_command("dev");
         assert!(cmd.starts_with("id -u dev"));
-        assert!(cmd.contains("adduser -D -h /home/dev dev"));
+        // useradd tried first, then Debian adduser, then Alpine adduser
         assert!(cmd.contains("useradd -m -s /bin/sh dev"));
+        assert!(cmd.contains("adduser --disabled-password --gecos '' dev"));
+        assert!(cmd.contains("adduser -D -h /home/dev dev"));
     }
 
     #[test]

--- a/src/cmd/exec.rs
+++ b/src/cmd/exec.rs
@@ -482,14 +482,15 @@ fn ensure_user_command(user: &str) -> String {
     )
 }
 
-/// Wrap a command with `runuser -u {user} -- sh -c '...'` when `run_as` is set.
+/// Wrap a command with `runuser -u {user} -- {command}` when `run_as` is set.
 /// Network, CA, and mount setup run as root; only the user command drops privileges.
+/// Uses `--` to separate runuser flags from the command; no extra sh -c layer
+/// so the guest TTY passes through for interactive agents.
 fn wrap_run_as(command: &str, run_as: Option<&str>) -> String {
     let Some(user) = run_as else {
         return command.to_string();
     };
-    let escaped = command.replace('\'', "'\\''");
-    format!("runuser -u {user} -- sh -c '{escaped}'")
+    format!("runuser -u {user} -- {command}")
 }
 
 fn write_guest_policy(rootfs: &Path, allowed_hosts: Option<&Vec<String>>) {
@@ -611,26 +612,14 @@ mod tests {
         let result = wrap_run_as("claude --dangerously-skip-permissions", Some("dev"));
         assert_eq!(
             result,
-            "runuser -u dev -- sh -c 'claude --dangerously-skip-permissions'"
+            "runuser -u dev -- claude --dangerously-skip-permissions"
         );
     }
 
     #[test]
-    fn wrap_run_as_escapes_single_quotes() {
+    fn wrap_run_as_preserves_command_verbatim() {
         let result = wrap_run_as("echo 'hello world'", Some("dev"));
-        assert_eq!(
-            result,
-            "runuser -u dev -- sh -c 'echo '\\''hello world'\\'''"
-        );
-    }
-
-    #[test]
-    fn wrap_run_as_with_setup_command() {
-        let cmd = "mkdir -p /tmp/.claude && cp /redan/host-claude-config/.credentials.json /tmp/.claude/.credentials.json && chmod 600 /tmp/.claude/.credentials.json && claude --dangerously-skip-permissions";
-        let result = wrap_run_as(cmd, Some("dev"));
-        assert!(result.starts_with("runuser -u dev -- sh -c '"));
-        assert!(result.contains("mkdir -p /tmp/.claude"));
-        assert!(result.ends_with("claude --dangerously-skip-permissions'"));
+        assert_eq!(result, "runuser -u dev -- echo 'hello world'");
     }
 
     #[test]

--- a/src/cmd/exec.rs
+++ b/src/cmd/exec.rs
@@ -166,6 +166,14 @@ pub(crate) fn run(cfg: &ExecConfig<'_>) {
         mount_commands.push(format!("mount -t virtiofs{mount_opts} {tag} {guest_path}"));
     }
 
+    // Validate run_as username before interpolating into shell commands
+    if let Some(user) = cfg.run_as
+        && let Err(msg) = validate_username(user)
+    {
+        eprintln!("invalid --run-as username: {msg}");
+        std::process::exit(1);
+    }
+
     // Build guest command: network setup + CA trust + mounts + user command
     let net_setup = vm::net_setup_commands(&proxy::GATEWAY_IP.to_string(), proxy::GUEST_IP);
     let ca_update = vm::ca_update_commands();
@@ -468,6 +476,22 @@ pub(crate) fn parse_mount(spec: &str) -> (String, String, bool) {
     }
 }
 
+fn validate_username(user: &str) -> Result<(), String> {
+    if user.is_empty() {
+        return Err("username must not be empty".into());
+    }
+    if user.len() > 32 {
+        return Err(format!("username too long ({} chars, max 32)", user.len()));
+    }
+    if !user
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+    {
+        return Err(format!("username contains invalid characters: {user:?}"));
+    }
+    Ok(())
+}
+
 /// Shell command that creates the target user if it doesn't exist.
 /// Runs as root in the init script, before `runuser` drops privileges.
 /// Tries useradd (shadow-utils), Debian adduser, then Alpine/BusyBox
@@ -630,6 +654,32 @@ mod tests {
         assert!(cmd.contains("useradd -m -s /bin/sh dev"));
         assert!(cmd.contains("adduser --disabled-password --gecos '' dev"));
         assert!(cmd.contains("adduser -D -h /home/dev dev"));
+    }
+
+    #[test]
+    fn validate_username_accepts_valid() {
+        assert!(validate_username("dev").is_ok());
+        assert!(validate_username("claude-code").is_ok());
+        assert!(validate_username("user_123").is_ok());
+        assert!(validate_username("a").is_ok());
+    }
+
+    #[test]
+    fn validate_username_rejects_empty() {
+        assert!(validate_username("").is_err());
+    }
+
+    #[test]
+    fn validate_username_rejects_shell_injection() {
+        assert!(validate_username("dev; rm -rf /").is_err());
+        assert!(validate_username("$(whoami)").is_err());
+        assert!(validate_username("dev\nroot").is_err());
+    }
+
+    #[test]
+    fn validate_username_rejects_too_long() {
+        let long = "a".repeat(33);
+        assert!(validate_username(&long).is_err());
     }
 
     #[test]

--- a/src/cmd/exec.rs
+++ b/src/cmd/exec.rs
@@ -38,7 +38,9 @@ pub(crate) struct ExecConfig<'a> {
     pub browser: bool,
 }
 
-pub(crate) fn run(cfg: &ExecConfig<'_>) {
+/// Run a sandboxed VM session to completion.
+/// Returns the guest exit code, which the caller should propagate.
+pub(crate) fn run(cfg: &ExecConfig<'_>) -> i32 {
     // Create or reuse session
     let session_id = cfg.session_id.map_or_else(session::new_id, Into::into);
     if cfg.session_id.is_some() && !session::valid_session_id(&session_id) {
@@ -264,11 +266,22 @@ pub(crate) fn run(cfg: &ExecConfig<'_>) {
     // implicit console setup (setup_terminal_raw_mode). Calling cfmakeraw
     // here before libkrun breaks console output due to interaction between
     // the pre-existing raw mode and libkrun's make_non_blocking on dup'd fds.
-    if cfg.interactive {
-        redan::terminal::save_terminal_for_atexit();
-    }
+    // Save the state so the parent can restore it after reaping the VM
+    // child; libkrun raw-modes the TTY whenever stdin is one, not just
+    // in interactive mode.
+    redan::terminal::save_terminal();
 
     let vm_handle = vm::Vm::boot(vm_config);
+
+    // Ignore SIGINT in the parent. Ctrl-C must reach the guest, not kill
+    // redan: the terminal delivers SIGINT to the whole foreground process
+    // group, and the VM child (libkrun) forwards it to the guest console.
+    // The guest agent handles it (or its shell exits), the VM child dies,
+    // and the parent cleans up through the normal reap path.
+    // SAFETY: SIG_IGN disposition change, no handler code involved.
+    unsafe {
+        libc::signal(libc::SIGINT, libc::SIG_IGN);
+    }
 
     let net_sock = match vm_handle.net_sock.try_clone() {
         Ok(s) => s,
@@ -352,6 +365,12 @@ pub(crate) fn run(cfg: &ExecConfig<'_>) {
         forwards: &forwards,
     });
 
+    // Reap the VM child (kills it first if the proxy hit its timeout
+    // while the guest was still running) and restore the terminal.
+    // libkrun restores it on clean guest shutdown, but not when killed.
+    let guest_code = vm_handle.shutdown();
+    redan::terminal::restore_saved_terminal();
+
     if cfg.discover && !discovered.is_empty() {
         eprintln!("\n--- discovered hosts ---");
         eprintln!("The agent connected to these hosts:\n");
@@ -367,8 +386,9 @@ pub(crate) fn run(cfg: &ExecConfig<'_>) {
         eprintln!("]");
     }
 
-    meta.finish(true);
-    log::info!("session {session_id} finished");
+    meta.finish(guest_code == 0);
+    log::info!("session {session_id} finished (guest exit code {guest_code})");
+    guest_code
 }
 
 /// Redact a secret spec for error messages. Shows `ENV_VAR=<redacted>:hosts`.

--- a/src/cmd/exec.rs
+++ b/src/cmd/exec.rs
@@ -25,6 +25,8 @@ pub(crate) struct ExecConfig<'a> {
     pub session_name: Option<&'a str>,
     /// Pre-existing session ID (for daemon mode). If None, creates a new session.
     pub session_id: Option<&'a str>,
+    /// Run the user command as this OS user (via `runuser`).
+    pub run_as: Option<&'a str>,
 }
 
 pub(crate) fn run(cfg: &ExecConfig<'_>) {
@@ -166,10 +168,11 @@ pub(crate) fn run(cfg: &ExecConfig<'_>) {
     let net_setup = vm::net_setup_commands(&proxy::GATEWAY_IP.to_string(), proxy::GUEST_IP);
     let ca_update = vm::ca_update_commands();
     let mount_setup = mount_commands.join("; ");
+    let user_command = wrap_run_as(cfg.command, cfg.run_as);
     let full_command = if mount_setup.is_empty() {
-        format!("{net_setup}; {ca_update}; {}", cfg.command)
+        format!("{net_setup}; {ca_update}; {user_command}")
     } else {
-        format!("{net_setup}; {ca_update}; {mount_setup}; {}", cfg.command)
+        format!("{net_setup}; {ca_update}; {mount_setup}; {user_command}")
     };
 
     let mut env: Vec<String> = vec![
@@ -407,6 +410,16 @@ pub(crate) fn parse_mount(spec: &str) -> (String, String, bool) {
     }
 }
 
+/// Wrap a command with `runuser -u {user} -- sh -c '...'` when `run_as` is set.
+/// Network, CA, and mount setup run as root; only the user command drops privileges.
+fn wrap_run_as(command: &str, run_as: Option<&str>) -> String {
+    let Some(user) = run_as else {
+        return command.to_string();
+    };
+    let escaped = command.replace('\'', "'\\''");
+    format!("runuser -u {user} -- sh -c '{escaped}'")
+}
+
 fn write_guest_policy(rootfs: &Path, allowed_hosts: Option<&Vec<String>>) {
     let dir = rootfs.join("etc/redan");
     if std::fs::create_dir_all(&dir).is_err() {
@@ -514,6 +527,38 @@ mod tests {
         assert_eq!(host, "/home/chris/.claude");
         assert_eq!(guest, "/workspace");
         assert!(ro);
+    }
+
+    #[test]
+    fn wrap_run_as_none_passthrough() {
+        assert_eq!(wrap_run_as("echo hello", None), "echo hello");
+    }
+
+    #[test]
+    fn wrap_run_as_wraps_with_runuser() {
+        let result = wrap_run_as("claude --dangerously-skip-permissions", Some("dev"));
+        assert_eq!(
+            result,
+            "runuser -u dev -- sh -c 'claude --dangerously-skip-permissions'"
+        );
+    }
+
+    #[test]
+    fn wrap_run_as_escapes_single_quotes() {
+        let result = wrap_run_as("echo 'hello world'", Some("dev"));
+        assert_eq!(
+            result,
+            "runuser -u dev -- sh -c 'echo '\\''hello world'\\'''"
+        );
+    }
+
+    #[test]
+    fn wrap_run_as_with_setup_command() {
+        let cmd = "mkdir -p /tmp/.claude && cp /redan/host-claude-config/.credentials.json /tmp/.claude/.credentials.json && chmod 600 /tmp/.claude/.credentials.json && claude --dangerously-skip-permissions";
+        let result = wrap_run_as(cmd, Some("dev"));
+        assert!(result.starts_with("runuser -u dev -- sh -c '"));
+        assert!(result.contains("mkdir -p /tmp/.claude"));
+        assert!(result.ends_with("claude --dangerously-skip-permissions'"));
     }
 
     #[test]

--- a/src/cmd/exec.rs
+++ b/src/cmd/exec.rs
@@ -27,6 +27,9 @@ pub(crate) struct ExecConfig<'a> {
     pub session_id: Option<&'a str>,
     /// Run the user command as this OS user (via `runuser`).
     pub run_as: Option<&'a str>,
+    /// Guest directory to chown to `run_as` user before the user command runs.
+    /// Used for staged credentials that the agent needs to write back to.
+    pub chown_dir: Option<&'a str>,
     /// Launch headless Chrome with CDP and an allowlist proxy.
     pub browser: bool,
 }
@@ -187,6 +190,14 @@ pub(crate) fn run(cfg: &ExecConfig<'_>) {
     }
     if let Some(cmd) = ensure_user {
         parts.push(cmd);
+    }
+    if let (Some(_), Some(dir)) = (cfg.run_as, cfg.chown_dir) {
+        // chown doesn't work through virtiofs (host user != VM root), so
+        // open permissions instead. Single-user VM, so this is safe.
+        // Use find instead of glob: shell `*` skips dotfiles like .credentials.json.
+        parts.push(format!(
+            "chmod 777 {dir} && find {dir} -maxdepth 1 -type f -exec chmod 666 {{}} +; true"
+        ));
     }
     parts.push(user_command);
     let full_command = parts.join("; ");

--- a/src/cmd/exec.rs
+++ b/src/cmd/exec.rs
@@ -9,6 +9,7 @@ use redan::session;
 use redan::templates;
 use redan::vm;
 
+#[allow(clippy::struct_excessive_bools)]
 pub(crate) struct ExecConfig<'a> {
     pub rootfs: &'a str,
     pub command: &'a str,
@@ -30,6 +31,9 @@ pub(crate) struct ExecConfig<'a> {
     /// Guest directory to chown to `run_as` user before the user command runs.
     /// Used for staged credentials that the agent needs to write back to.
     pub chown_dir: Option<&'a str>,
+    /// Redirect logs to session file (avoids interleaving with guest output).
+    /// True whenever stdin is a TTY.
+    pub redirect_logs: bool,
     /// Launch headless Chrome with CDP and an allowlist proxy.
     pub browser: bool,
 }
@@ -62,9 +66,8 @@ pub(crate) fn run(cfg: &ExecConfig<'_>) {
     };
     log::info!("session {session_id} started");
 
-    // In interactive mode, redirect logs to a file so they don't
-    // interleave with the guest TUI.
-    if cfg.interactive {
+    // Redirect logs to a file so they don't interleave with guest output.
+    if cfg.redirect_logs {
         let log_path = session::session_dir(&session_id).join("redan.log");
         eprintln!("session: {session_id} (logs: {})", log_path.display());
         crate::redirect_logs_to_file(&log_path);
@@ -249,26 +252,21 @@ pub(crate) fn run(cfg: &ExecConfig<'_>) {
 
     let vm_config = vm::VmConfig {
         rootfs: cfg.rootfs.into(),
-        vcpus: 1,
-        ram_mib: 256,
+        vcpus: 4,
+        ram_mib: 4096,
         command: full_command,
         env,
         virtiofs_mounts,
         interactive: cfg.interactive,
     };
 
-    // In interactive mode, set the host terminal to raw mode
-    let _raw_guard = if cfg.interactive {
-        match redan::terminal::RawTerminalGuard::enter() {
-            Ok(guard) => Some(guard),
-            Err(e) => {
-                eprintln!("warning: cannot enter raw terminal mode: {e}");
-                None
-            }
-        }
-    } else {
-        None
-    };
+    // libkrun handles raw terminal mode inside krun_start_enter via its
+    // implicit console setup (setup_terminal_raw_mode). Calling cfmakeraw
+    // here before libkrun breaks console output due to interaction between
+    // the pre-existing raw mode and libkrun's make_non_blocking on dup'd fds.
+    if cfg.interactive {
+        redan::terminal::save_terminal_for_atexit();
+    }
 
     let vm_handle = vm::Vm::boot(vm_config);
 

--- a/src/cmd/exec.rs
+++ b/src/cmd/exec.rs
@@ -319,6 +319,16 @@ pub(crate) fn run(cfg: &ExecConfig<'_>) -> i32 {
             allowed_hosts: allowed_hosts.clone(),
         }) {
             Ok(b) => {
+                // Chrome shares the agent's allowlist. Make the scope explicit
+                // so an agent that can't reach a site reads it as policy, not breakage.
+                match &allowed_hosts {
+                    Some(h) if h.is_empty() => log::info!(
+                        "browser: Chrome egress blocked (default-deny); pass --allow-host to let Chrome reach sites"
+                    ),
+                    Some(h) => log::info!("browser: Chrome egress limited to {}", h.join(", ")),
+                    None => log::info!("browser: Chrome egress unrestricted (--allow-host '*')"),
+                }
+
                 // Add CDP forward so the guest can reach Chrome
                 let cdp_fwd = proxy::ForwardSpec {
                     guest_port: redan::browser::CDP_PORT,

--- a/src/cmd/exec.rs
+++ b/src/cmd/exec.rs
@@ -170,12 +170,18 @@ pub(crate) fn run(cfg: &ExecConfig<'_>) {
     let net_setup = vm::net_setup_commands(&proxy::GATEWAY_IP.to_string(), proxy::GUEST_IP);
     let ca_update = vm::ca_update_commands();
     let mount_setup = mount_commands.join("; ");
+    let ensure_user = cfg.run_as.map(ensure_user_command);
     let user_command = wrap_run_as(cfg.command, cfg.run_as);
-    let full_command = if mount_setup.is_empty() {
-        format!("{net_setup}; {ca_update}; {user_command}")
-    } else {
-        format!("{net_setup}; {ca_update}; {mount_setup}; {user_command}")
-    };
+
+    let mut parts = vec![net_setup, ca_update.to_string()];
+    if !mount_setup.is_empty() {
+        parts.push(mount_setup);
+    }
+    if let Some(cmd) = ensure_user {
+        parts.push(cmd);
+    }
+    parts.push(user_command);
+    let full_command = parts.join("; ");
 
     let mut env: Vec<String> = vec![
         "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin".into(),
@@ -462,6 +468,17 @@ pub(crate) fn parse_mount(spec: &str) -> (String, String, bool) {
     }
 }
 
+/// Shell command that creates the target user if it doesn't exist.
+/// Runs as root in the init script, before `runuser` drops privileges.
+/// Handles both Alpine (adduser) and Debian/Ubuntu (useradd).
+fn ensure_user_command(user: &str) -> String {
+    format!(
+        "id -u {user} >/dev/null 2>&1 || \
+         {{ command -v adduser >/dev/null 2>&1 && adduser -D -h /home/{user} {user} || \
+         useradd -m -s /bin/sh {user}; }}"
+    )
+}
+
 /// Wrap a command with `runuser -u {user} -- sh -c '...'` when `run_as` is set.
 /// Network, CA, and mount setup run as root; only the user command drops privileges.
 fn wrap_run_as(command: &str, run_as: Option<&str>) -> String {
@@ -611,6 +628,14 @@ mod tests {
         assert!(result.starts_with("runuser -u dev -- sh -c '"));
         assert!(result.contains("mkdir -p /tmp/.claude"));
         assert!(result.ends_with("claude --dangerously-skip-permissions'"));
+    }
+
+    #[test]
+    fn ensure_user_command_creates_user() {
+        let cmd = ensure_user_command("dev");
+        assert!(cmd.starts_with("id -u dev"));
+        assert!(cmd.contains("adduser -D -h /home/dev dev"));
+        assert!(cmd.contains("useradd -m -s /bin/sh dev"));
     }
 
     #[test]

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -5,6 +5,11 @@
 use std::os::raw::{c_char, c_int};
 
 pub const KRUN_LOG_LEVEL_OFF: u32 = 0;
+pub const KRUN_LOG_LEVEL_ERROR: u32 = 1;
+pub const KRUN_LOG_LEVEL_WARN: u32 = 2;
+pub const KRUN_LOG_LEVEL_INFO: u32 = 3;
+pub const KRUN_LOG_LEVEL_DEBUG: u32 = 4;
+pub const KRUN_LOG_LEVEL_TRACE: u32 = 5;
 pub const KRUN_LOG_STYLE_AUTO: u32 = 0;
 pub const KRUN_LOG_TARGET_DEFAULT: c_int = -1;
 

--- a/src/image.rs
+++ b/src/image.rs
@@ -250,6 +250,10 @@ fn build_image(dest: &Path, packages: &[String], run_commands: &[String]) -> io:
         forwards: &[],
     });
 
+    // Reap the build VM (kills it if the proxy timed out instead).
+    // The sentinel file is the source of truth for build success.
+    let _ = vm_handle.shutdown();
+
     // Verify the build completed successfully by checking for the
     // sentinel file written as the last build step.
     let sentinel = dest.join("tmp/.redan-build-ok");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 #![allow(clippy::module_name_repetitions)]
 
 pub mod auto_detect;
+pub mod browser;
 pub mod ca;
 pub mod config;
 pub mod dns;

--- a/src/main.rs
+++ b/src/main.rs
@@ -315,6 +315,7 @@ fn main() {
                 discover,
                 detach,
                 name,
+                run_as: None,
             });
         }
         Cli::Attach { session } => attach_session(session.as_deref()),
@@ -492,6 +493,7 @@ struct ExecArgs {
     discover: bool,
     detach: bool,
     name: Option<String>,
+    run_as: Option<String>,
 }
 
 fn exec_command(args: ExecArgs) {
@@ -514,8 +516,8 @@ fn exec_command(args: ExecArgs) {
     // 1. Config file exists → use it (existing behavior)
     // 2. Explicit CLI flags → use them (existing behavior)
     // 3. Neither → try auto-detect
-    let cfg = if let Some((_, cfg)) = config_file {
-        cfg
+    let (cfg, run_as) = if let Some((_, cfg)) = config_file {
+        (cfg, None)
     } else if !explicit {
         // No config, no explicit flags: try auto-detect
         if let Some(auto) = redan::auto_detect::detect() {
@@ -532,7 +534,8 @@ fn exec_command(args: ExecArgs) {
             for msg in &auto.messages {
                 eprintln!("  {msg}");
             }
-            auto.config
+            let run_as = auto.run_as.map(Into::into);
+            (auto.config, run_as)
         } else {
             eprintln!("no redan.toml found and auto-detect failed.");
             eprintln!();
@@ -550,8 +553,9 @@ fn exec_command(args: ExecArgs) {
             std::process::exit(1);
         }
     } else {
-        config::Config::default()
+        (config::Config::default(), None)
     };
+    let run_as = args.run_as.or(run_as);
 
     let mut all_secrets =
         cmd::exec::collect_secret_specs(&args.secrets, args.secret_file.as_deref());
@@ -641,6 +645,7 @@ fn exec_command(args: ExecArgs) {
             &cfg.env,
             args.discover,
             args.name.as_deref(),
+            run_as.as_deref(),
         );
     } else {
         cmd::exec::run(&cmd::exec::ExecConfig {
@@ -658,6 +663,7 @@ fn exec_command(args: ExecArgs) {
             discover: args.discover,
             session_name: args.name.as_deref(),
             session_id: None,
+            run_as: run_as.as_deref(),
         });
     }
 }
@@ -677,6 +683,7 @@ struct DaemonConfig {
     env: std::collections::BTreeMap<String, String>,
     discover: bool,
     session_name: Option<String>,
+    run_as: Option<String>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -693,6 +700,7 @@ fn exec_detached(
     env: &std::collections::BTreeMap<String, String>,
     discover: bool,
     session_name: Option<&str>,
+    run_as: Option<&str>,
 ) {
     // Create session directory and write daemon config.
     // Directory is 0o700 and config file is 0o600 because the config
@@ -723,6 +731,7 @@ fn exec_detached(
         env: env.clone(),
         discover,
         session_name: session_name.map(Into::into),
+        run_as: run_as.map(Into::into),
     };
 
     let config_path = session_dir.join("daemon_config.json");
@@ -849,6 +858,7 @@ fn run_daemon(session_id: &str) {
         discover: cfg.discover,
         session_name: cfg.session_name.as_deref(),
         session_id: Some(session_id),
+        run_as: cfg.run_as.as_deref(),
     });
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -159,6 +159,13 @@ enum Cli {
         #[arg(long)]
         discover: bool,
 
+        /// Launch headless Chrome on the host with CDP access from the guest.
+        /// Chrome's outbound traffic goes through an allowlist proxy (same
+        /// hosts as `--allow-host`). The guest sees `REDAN_BROWSER=1`,
+        /// `REDAN_BROWSER_HOST`, and `REDAN_BROWSER_CDP_PORT` env vars.
+        #[arg(long)]
+        browser: bool,
+
         /// Run session in the background. Use `redan attach` to reconnect.
         #[arg(long, short = 'd')]
         detach: bool,
@@ -296,6 +303,7 @@ fn main() {
             mounts,
             audit_log,
             log_file: _,
+            browser,
             discover,
             detach,
             name,
@@ -316,6 +324,7 @@ fn main() {
                 detach,
                 name,
                 run_as: None,
+                browser,
             });
         }
         Cli::Attach { session } => attach_session(session.as_deref()),
@@ -478,6 +487,7 @@ fn main() {
     }
 }
 
+#[allow(clippy::struct_excessive_bools)] // CLI flags map naturally to bools
 struct ExecArgs {
     image_name: Option<String>,
     rootfs: Option<String>,
@@ -494,6 +504,7 @@ struct ExecArgs {
     detach: bool,
     name: Option<String>,
     run_as: Option<String>,
+    browser: bool,
 }
 
 fn exec_command(args: ExecArgs) {
@@ -646,6 +657,7 @@ fn exec_command(args: ExecArgs) {
             args.discover,
             args.name.as_deref(),
             run_as.as_deref(),
+            args.browser,
         );
     } else {
         cmd::exec::run(&cmd::exec::ExecConfig {
@@ -664,6 +676,7 @@ fn exec_command(args: ExecArgs) {
             session_name: args.name.as_deref(),
             session_id: None,
             run_as: run_as.as_deref(),
+            browser: args.browser,
         });
     }
 }
@@ -684,6 +697,7 @@ struct DaemonConfig {
     discover: bool,
     session_name: Option<String>,
     run_as: Option<String>,
+    browser: bool,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -701,6 +715,7 @@ fn exec_detached(
     discover: bool,
     session_name: Option<&str>,
     run_as: Option<&str>,
+    browser: bool,
 ) {
     // Create session directory and write daemon config.
     // Directory is 0o700 and config file is 0o600 because the config
@@ -732,6 +747,7 @@ fn exec_detached(
         discover,
         session_name: session_name.map(Into::into),
         run_as: run_as.map(Into::into),
+        browser,
     };
 
     let config_path = session_dir.join("daemon_config.json");
@@ -859,6 +875,7 @@ fn run_daemon(session_id: &str) {
         session_name: cfg.session_name.as_deref(),
         session_id: Some(session_id),
         run_as: cfg.run_as.as_deref(),
+        browser: cfg.browser,
     });
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -637,6 +637,7 @@ fn exec_command(args: ExecArgs) {
     };
     // Stage credentials into the rootfs before boot (like CA cert install).
     // Runs on the host, no mount or runtime copy needed.
+    let chown_dir: Option<String> = stage_credentials.as_ref().map(|(_, d, _)| d.clone());
     if let Some((host_path, guest_dir, filename)) = &stage_credentials {
         let target_dir = std::path::Path::new(&rootfs_path)
             .join(guest_dir.strip_prefix('/').unwrap_or(guest_dir));
@@ -656,7 +657,10 @@ fn exec_command(args: ExecArgs) {
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
-            let _ = std::fs::set_permissions(&target_file, std::fs::Permissions::from_mode(0o644));
+            // World-writable so the run_as user can update credentials.
+            // Single-user VM; the VM itself is the security boundary.
+            let _ = std::fs::set_permissions(&target_dir, std::fs::Permissions::from_mode(0o777));
+            let _ = std::fs::set_permissions(&target_file, std::fs::Permissions::from_mode(0o666));
         }
     }
 
@@ -682,6 +686,7 @@ fn exec_command(args: ExecArgs) {
             args.discover,
             args.name.as_deref(),
             run_as.as_deref(),
+            chown_dir.as_deref(),
             args.browser,
         );
     } else {
@@ -701,6 +706,7 @@ fn exec_command(args: ExecArgs) {
             session_name: args.name.as_deref(),
             session_id: None,
             run_as: run_as.as_deref(),
+            chown_dir: chown_dir.as_deref(),
             browser: args.browser,
         });
     }
@@ -722,6 +728,7 @@ struct DaemonConfig {
     discover: bool,
     session_name: Option<String>,
     run_as: Option<String>,
+    chown_dir: Option<String>,
     browser: bool,
 }
 
@@ -740,6 +747,7 @@ fn exec_detached(
     discover: bool,
     session_name: Option<&str>,
     run_as: Option<&str>,
+    chown_dir: Option<&str>,
     browser: bool,
 ) {
     // Create session directory and write daemon config.
@@ -772,6 +780,7 @@ fn exec_detached(
         discover,
         session_name: session_name.map(Into::into),
         run_as: run_as.map(Into::into),
+        chown_dir: chown_dir.map(Into::into),
         browser,
     };
 
@@ -900,6 +909,7 @@ fn run_daemon(session_id: &str) {
         session_name: cfg.session_name.as_deref(),
         session_id: Some(session_id),
         run_as: cfg.run_as.as_deref(),
+        chown_dir: cfg.chown_dir.as_deref(),
         browser: cfg.browser,
     });
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -692,7 +692,7 @@ fn exec_command(args: ExecArgs) {
             args.browser,
         );
     } else {
-        cmd::exec::run(&cmd::exec::ExecConfig {
+        let guest_code = cmd::exec::run(&cmd::exec::ExecConfig {
             rootfs: &rootfs_path,
             command: &command,
             interactive,
@@ -712,6 +712,7 @@ fn exec_command(args: ExecArgs) {
             redirect_logs,
             browser: args.browser,
         });
+        std::process::exit(guest_code);
     }
 }
 
@@ -896,7 +897,7 @@ fn run_daemon(session_id: &str) {
     });
 
     // Run the VM+proxy (non-interactive: daemon has no terminal)
-    cmd::exec::run(&cmd::exec::ExecConfig {
+    let guest_code = cmd::exec::run(&cmd::exec::ExecConfig {
         rootfs: &cfg.rootfs,
         command: &cfg.command,
         interactive: false,
@@ -916,6 +917,7 @@ fn run_daemon(session_id: &str) {
         redirect_logs: false,
         browser: cfg.browser,
     });
+    std::process::exit(guest_code);
 }
 
 fn attach_session(id_or_name: Option<&str>) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,10 +96,10 @@ enum Cli {
         #[arg(long)]
         rootfs: Option<String>,
 
-        /// Command to run in the guest (everything after --).
+        /// Shell command to run in the guest.
         /// If omitted in interactive mode, defaults to /bin/sh.
-        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
-        command: Vec<String>,
+        #[arg(long, short = 'c')]
+        command: Option<String>,
 
         /// Interactive mode: attach terminal to guest console.
         #[arg(long, short = 'i')]
@@ -495,7 +495,7 @@ fn main() {
 struct ExecArgs {
     image_name: Option<String>,
     rootfs: Option<String>,
-    command: Vec<String>,
+    command: Option<String>,
     interactive: bool,
     timeout: Option<u64>,
     secrets: Vec<String>,
@@ -580,11 +580,7 @@ fn exec_command(args: ExecArgs) {
 
     let image_name = args.image_name.or_else(|| cfg.image.clone());
     let rootfs = args.rootfs.or_else(|| cfg.rootfs.clone());
-    let command = if args.command.is_empty() {
-        cfg.command.clone()
-    } else {
-        Some(shell_words::join(&args.command))
-    };
+    let command = args.command.or_else(|| cfg.command.clone());
     let timeout = args.timeout.or(cfg.timeout).unwrap_or(3600);
     let interactive = args.interactive || cfg.interactive.unwrap_or(false);
     let redirect_logs = interactive || redan::terminal::stdin_is_tty();

--- a/src/main.rs
+++ b/src/main.rs
@@ -527,8 +527,8 @@ fn exec_command(args: ExecArgs) {
     // 1. Config file exists → use it (existing behavior)
     // 2. Explicit CLI flags → use them (existing behavior)
     // 3. Neither → try auto-detect
-    let (cfg, run_as) = if let Some((_, cfg)) = config_file {
-        (cfg, None)
+    let (cfg, run_as, stage_credentials) = if let Some((_, cfg)) = config_file {
+        (cfg, None, None)
     } else if !explicit {
         // No config, no explicit flags: try auto-detect
         if let Some(auto) = redan::auto_detect::detect() {
@@ -546,7 +546,7 @@ fn exec_command(args: ExecArgs) {
                 eprintln!("  {msg}");
             }
             let run_as = auto.run_as.map(Into::into);
-            (auto.config, run_as)
+            (auto.config, run_as, auto.stage_credentials)
         } else {
             eprintln!("no redan.toml found and auto-detect failed.");
             eprintln!();
@@ -564,7 +564,7 @@ fn exec_command(args: ExecArgs) {
             std::process::exit(1);
         }
     } else {
-        (config::Config::default(), None)
+        (config::Config::default(), None, None)
     };
     let run_as = args.run_as.or(run_as);
 
@@ -635,6 +635,31 @@ fn exec_command(args: ExecArgs) {
             std::process::exit(1);
         }
     };
+    // Stage credentials into the rootfs before boot (like CA cert install).
+    // Runs on the host, no mount or runtime copy needed.
+    if let Some((host_path, guest_dir, filename)) = &stage_credentials {
+        let target_dir = std::path::Path::new(&rootfs_path)
+            .join(guest_dir.strip_prefix('/').unwrap_or(guest_dir));
+        if let Err(e) = std::fs::create_dir_all(&target_dir) {
+            eprintln!("error: cannot create {}: {e}", target_dir.display());
+            std::process::exit(1);
+        }
+        let target_file = target_dir.join(filename);
+        if let Err(e) = std::fs::copy(host_path, &target_file) {
+            eprintln!(
+                "error: cannot stage credentials {} → {}: {e}",
+                host_path.display(),
+                target_file.display()
+            );
+            std::process::exit(1);
+        }
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(&target_file, std::fs::Permissions::from_mode(0o644));
+        }
+    }
+
     let command = command.unwrap_or_else(|| {
         if interactive {
             "/bin/sh".to_string()

--- a/src/main.rs
+++ b/src/main.rs
@@ -264,6 +264,9 @@ enum ImageAction {
         /// Devcontainer directory or JSON path
         #[arg(long)]
         devcontainer: Option<String>,
+        /// Replace existing image if it already exists
+        #[arg(long, short = 'f')]
+        force: bool,
     },
 }
 
@@ -382,8 +385,9 @@ fn main() {
                 from,
                 dockerfile,
                 devcontainer,
+                force,
             } => {
-                let result = import_image(&name, from, dockerfile, devcontainer);
+                let result = import_image(&name, from, dockerfile, devcontainer, force);
                 if let Err(e) = result {
                     eprintln!("import failed: {e}");
                     std::process::exit(1);
@@ -527,17 +531,18 @@ fn exec_command(args: ExecArgs) {
     // 1. Config file exists → use it (existing behavior)
     // 2. Explicit CLI flags → use them (existing behavior)
     // 3. Neither → try auto-detect
-    let (cfg, run_as, stage_credentials) = if let Some((_, cfg)) = config_file {
-        (cfg, None, None)
+    let (cfg, run_as, stage_files) = if let Some((_, cfg)) = config_file {
+        (cfg, None, Vec::new())
     } else if !explicit {
         // No config, no explicit flags: try auto-detect
         if let Some(auto) = redan::auto_detect::detect() {
             if auto.needs_image_build {
-                eprintln!("Building claude-code image (this may take a minute)...");
-                match build_bundled_claude_image() {
-                    Ok(_) => eprintln!("Image claude-code built successfully."),
+                let image_name = auto.config.image.as_deref().unwrap_or("unknown");
+                eprintln!("Building {image_name} image (this may take a minute)...");
+                match build_bundled_image(image_name) {
+                    Ok(_) => eprintln!("Image {image_name} built successfully."),
                     Err(e) => {
-                        eprintln!("error: failed to build claude-code image: {e}");
+                        eprintln!("error: failed to build {image_name} image: {e}");
                         std::process::exit(1);
                     }
                 }
@@ -546,7 +551,7 @@ fn exec_command(args: ExecArgs) {
                 eprintln!("  {msg}");
             }
             let run_as = auto.run_as.map(Into::into);
-            (auto.config, run_as, auto.stage_credentials)
+            (auto.config, run_as, auto.stage_files)
         } else {
             eprintln!("no redan.toml found and auto-detect failed.");
             eprintln!();
@@ -564,7 +569,7 @@ fn exec_command(args: ExecArgs) {
             std::process::exit(1);
         }
     } else {
-        (config::Config::default(), None, None)
+        (config::Config::default(), None, Vec::new())
     };
     let run_as = args.run_as.or(run_as);
 
@@ -582,6 +587,7 @@ fn exec_command(args: ExecArgs) {
     };
     let timeout = args.timeout.or(cfg.timeout).unwrap_or(3600);
     let interactive = args.interactive || cfg.interactive.unwrap_or(false);
+    let redirect_logs = interactive || redan::terminal::stdin_is_tty();
     let audit_log = args.audit_log.or_else(|| cfg.audit_log.clone());
 
     let mut allow_hosts = args.allow_hosts;
@@ -637,8 +643,8 @@ fn exec_command(args: ExecArgs) {
     };
     // Stage credentials into the rootfs before boot (like CA cert install).
     // Runs on the host, no mount or runtime copy needed.
-    let chown_dir: Option<String> = stage_credentials.as_ref().map(|(_, d, _)| d.clone());
-    if let Some((host_path, guest_dir, filename)) = &stage_credentials {
+    let chown_dir: Option<String> = stage_files.first().map(|(_, d, _)| d.clone());
+    for (host_path, guest_dir, filename) in &stage_files {
         let target_dir = std::path::Path::new(&rootfs_path)
             .join(guest_dir.strip_prefix('/').unwrap_or(guest_dir));
         if let Err(e) = std::fs::create_dir_all(&target_dir) {
@@ -707,6 +713,7 @@ fn exec_command(args: ExecArgs) {
             session_id: None,
             run_as: run_as.as_deref(),
             chown_dir: chown_dir.as_deref(),
+            redirect_logs,
             browser: args.browser,
         });
     }
@@ -910,6 +917,7 @@ fn run_daemon(session_id: &str) {
         session_id: Some(session_id),
         run_as: cfg.run_as.as_deref(),
         chown_dir: cfg.chown_dir.as_deref(),
+        redirect_logs: false,
         browser: cfg.browser,
     });
 }
@@ -1141,7 +1149,15 @@ fn import_image(
     from: Option<String>,
     dockerfile: Option<String>,
     devcontainer: Option<String>,
+    force: bool,
 ) -> std::io::Result<()> {
+    if force
+        && let Ok(path) = image::image_path(name)
+        && path.exists()
+    {
+        eprintln!("removing existing image '{name}'...");
+        image::remove(name)?;
+    }
     if let Some(docker_image) = from {
         image::import_docker(name, &docker_image)?;
         return Ok(());
@@ -1208,15 +1224,27 @@ fn logs(session_id: Option<&str>, follow: bool) {
     }
 }
 
-/// Build the claude-code image from the Dockerfile embedded in the binary.
-/// This avoids depending on CWD containing the redan source tree.
-fn build_bundled_claude_image() -> std::io::Result<std::path::PathBuf> {
-    static DOCKERFILE: &str = include_str!("../dockerfiles/claude-code.dockerfile");
-    let tmp = std::env::temp_dir().join("redan-claude-code-build");
+/// Build an agent image from a Dockerfile embedded in the binary.
+fn build_bundled_image(name: &str) -> std::io::Result<std::path::PathBuf> {
+    static CLAUDE_CODE_DOCKERFILE: &str = include_str!("../dockerfiles/claude-code.dockerfile");
+    static PI_DOCKERFILE: &str = include_str!("../dockerfiles/pi.dockerfile");
+
+    let dockerfile = match name {
+        "claude-code" => CLAUDE_CODE_DOCKERFILE,
+        "pi" => PI_DOCKERFILE,
+        _ => {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                format!("no bundled Dockerfile for image '{name}'"),
+            ));
+        }
+    };
+
+    let tmp = std::env::temp_dir().join(format!("redan-{name}-build"));
     std::fs::create_dir_all(&tmp)?;
     let df_path = tmp.join("Dockerfile");
-    std::fs::write(&df_path, DOCKERFILE)?;
-    let result = image::import_dockerfile("claude-code", df_path.to_str().unwrap_or(""));
+    std::fs::write(&df_path, dockerfile)?;
+    let result = image::import_dockerfile(name, df_path.to_str().unwrap_or(""));
     let _ = std::fs::remove_dir_all(&tmp);
     result
 }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -330,8 +330,11 @@ pub fn run(cfg: ProxyConfig<'_>) -> Vec<String> {
                 iface.update_ip_addrs(|addrs| {
                     // /32 host route: smoltcp responds to ARP only for this IP.
                     let cidr = IpCidr::new(ip.into(), 32);
-                    if !addrs.contains(&cidr) {
-                        addrs.push(cidr).ok();
+                    if !addrs.contains(&cidr) && addrs.push(cidr).is_err() {
+                        log::warn!(
+                            "cannot add {ip} to interface: address table full \
+                             (raise SMOLTCP_IFACE_MAX_ADDR_COUNT)"
+                        );
                     }
                 });
             }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -27,12 +27,17 @@ pub fn host_terminal_size() -> Option<(u16, u16)> {
     }
 }
 
-/// Saved terminal state for the atexit handler. `krun_start_enter` calls
-/// `exit()`, bypassing Rust Drop impls, so we register a C atexit handler
-/// that restores the terminal from this global.
+/// Terminal state saved before booting the VM. libkrun puts the shared
+/// TTY into raw mode inside the VM child process; the parent restores
+/// from this global after reaping the child.
 static SAVED_TERMIOS: Mutex<Option<libc::termios>> = Mutex::new(None);
 
-extern "C" fn restore_terminal() {
+/// Restore the terminal to the state captured by [`save_terminal`].
+///
+/// No-op if nothing was saved. Idempotent: safe to call when the VM
+/// child already restored the terminal itself (libkrun's exit observers
+/// do this on clean guest shutdown, but not when the child is killed).
+pub fn restore_saved_terminal() {
     if let Ok(guard) = SAVED_TERMIOS.lock()
         && let Some(ref original) = *guard
     {
@@ -92,13 +97,10 @@ impl Drop for RawTerminalGuard {
     }
 }
 
-/// Save the current terminal state and register an atexit handler,
-/// without modifying the terminal mode.
-///
-/// libkrun's `setup_terminal_raw_mode` handles entering raw mode inside
-/// `krun_start_enter`. This function provides a safety net: if libkrun's
-/// exit observers fail to restore, the atexit handler will.
-pub fn save_terminal_for_atexit() {
+/// Save the current terminal state for [`restore_saved_terminal`],
+/// without modifying the terminal mode. No-op if stdin is not a TTY
+/// or a state was already saved.
+pub fn save_terminal() {
     unsafe {
         if libc::isatty(libc::STDIN_FILENO) != 1 {
             return;
@@ -112,7 +114,6 @@ pub fn save_terminal_for_atexit() {
             && saved.is_none()
         {
             *saved = Some(current);
-            libc::atexit(restore_terminal);
         }
     }
 }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -1,8 +1,54 @@
 //! Terminal handling utilities.
 
 use std::io;
+use std::sync::Mutex;
+
+pub fn stdin_is_tty() -> bool {
+    unsafe { libc::isatty(libc::STDIN_FILENO) == 1 }
+}
+
+/// Read the host terminal's window size (columns, rows).
+/// Returns None if stdin is not a TTY or the ioctl fails.
+pub fn host_terminal_size() -> Option<(u16, u16)> {
+    unsafe {
+        if libc::isatty(libc::STDIN_FILENO) != 1 {
+            return None;
+        }
+        let mut ws = std::mem::MaybeUninit::<libc::winsize>::uninit();
+        if libc::ioctl(libc::STDIN_FILENO, libc::TIOCGWINSZ, ws.as_mut_ptr()) != 0 {
+            return None;
+        }
+        let ws = ws.assume_init();
+        if ws.ws_col > 0 && ws.ws_row > 0 {
+            Some((ws.ws_col, ws.ws_row))
+        } else {
+            None
+        }
+    }
+}
+
+/// Saved terminal state for the atexit handler. `krun_start_enter` calls
+/// `exit()`, bypassing Rust Drop impls, so we register a C atexit handler
+/// that restores the terminal from this global.
+static SAVED_TERMIOS: Mutex<Option<libc::termios>> = Mutex::new(None);
+
+extern "C" fn restore_terminal() {
+    if let Ok(guard) = SAVED_TERMIOS.lock()
+        && let Some(ref original) = *guard
+    {
+        unsafe {
+            libc::tcsetattr(
+                libc::STDIN_FILENO,
+                libc::TCSANOW,
+                std::ptr::from_ref(original),
+            );
+        }
+    }
+}
 
 /// RAII guard: raw terminal mode on creation, restore on drop.
+/// Used by `redan attach` for direct socket-to-terminal relay.
+/// NOT used by `redan exec`; libkrun handles raw mode for the VM console.
 pub struct RawTerminalGuard {
     original: libc::termios,
 }
@@ -12,9 +58,6 @@ impl RawTerminalGuard {
     /// or the termios syscalls fail.
     pub fn enter() -> io::Result<Self> {
         unsafe {
-            // SAFETY: isatty, tcgetattr, tcsetattr are POSIX-specified and
-            // safe to call with STDIN_FILENO. MaybeUninit avoids reading
-            // uninitialized memory if tcgetattr fails.
             if libc::isatty(libc::STDIN_FILENO) != 1 {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidInput,
@@ -26,6 +69,7 @@ impl RawTerminalGuard {
                 return Err(io::Error::last_os_error());
             }
             let original = original.assume_init();
+
             let mut raw = original;
             libc::cfmakeraw(std::ptr::from_mut(&mut raw));
             if libc::tcsetattr(libc::STDIN_FILENO, libc::TCSANOW, std::ptr::from_ref(&raw)) != 0 {
@@ -44,6 +88,31 @@ impl Drop for RawTerminalGuard {
                 libc::TCSANOW,
                 std::ptr::from_ref(&self.original),
             );
+        }
+    }
+}
+
+/// Save the current terminal state and register an atexit handler,
+/// without modifying the terminal mode.
+///
+/// libkrun's `setup_terminal_raw_mode` handles entering raw mode inside
+/// `krun_start_enter`. This function provides a safety net: if libkrun's
+/// exit observers fail to restore, the atexit handler will.
+pub fn save_terminal_for_atexit() {
+    unsafe {
+        if libc::isatty(libc::STDIN_FILENO) != 1 {
+            return;
+        }
+        let mut current = std::mem::MaybeUninit::<libc::termios>::uninit();
+        if libc::tcgetattr(libc::STDIN_FILENO, current.as_mut_ptr()) != 0 {
+            return;
+        }
+        let current = current.assume_init();
+        if let Ok(mut saved) = SAVED_TERMIOS.lock()
+            && saved.is_none()
+        {
+            *saved = Some(current);
+            libc::atexit(restore_terminal);
         }
     }
 }

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -80,7 +80,7 @@ pub const fn is_private_ip(ip: std::net::Ipv4Addr) -> bool {
         | [100, 64..=127, ..] // 100.64.0.0/10 (CGN, RFC 6598)
         | [192, 0, 0, ..]     // 192.0.0.0/24 (IETF protocol assignments)
         | [198, 18..=19, ..]  // 198.18.0.0/15 (benchmarking)
-        | [233..=239, ..] // 224.0.0.0/4 (multicast, partial)
+        | [224..=239, ..] // 224.0.0.0/4 (multicast)
     )
 }
 
@@ -256,6 +256,9 @@ mod tests {
         // CGN
         assert!(is_private_ip(Ipv4Addr::new(100, 64, 0, 1)));
         assert!(is_private_ip(Ipv4Addr::new(100, 127, 255, 255)));
+        // Multicast
+        assert!(is_private_ip(Ipv4Addr::new(224, 0, 0, 1)));
+        assert!(is_private_ip(Ipv4Addr::new(239, 255, 255, 255)));
     }
 
     #[test]

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -67,7 +67,7 @@ pub fn connect_upstream(
 /// Returns true if the IP is in a private, loopback, or link-local range.
 /// Used to block SSRF to cloud metadata endpoints and internal services.
 #[allow(clippy::unnested_or_patterns)] // Nesting destroys per-range comments
-pub(crate) const fn is_private_ip(ip: std::net::Ipv4Addr) -> bool {
+pub const fn is_private_ip(ip: std::net::Ipv4Addr) -> bool {
     let octets = ip.octets();
     matches!(
         octets,

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -101,10 +101,17 @@ impl Vm {
                 libc::setrlimit(libc::RLIMIT_NOFILE, &raw const limit);
             }
         }
+        let krun_log_level = match std::env::var("RUST_LOG").as_deref() {
+            Ok("trace") => ffi::KRUN_LOG_LEVEL_TRACE,
+            Ok("debug") => ffi::KRUN_LOG_LEVEL_DEBUG,
+            Ok(s) if s.contains("trace") => ffi::KRUN_LOG_LEVEL_TRACE,
+            Ok(s) if s.contains("debug") => ffi::KRUN_LOG_LEVEL_DEBUG,
+            _ => ffi::KRUN_LOG_LEVEL_OFF,
+        };
         let ret = unsafe {
             ffi::krun_init_log(
                 ffi::KRUN_LOG_TARGET_DEFAULT,
-                ffi::KRUN_LOG_LEVEL_OFF,
+                krun_log_level,
                 ffi::KRUN_LOG_STYLE_AUTO,
                 0,
             )

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1,14 +1,22 @@
 /// libkrun microVM lifecycle.
 ///
 /// Handles VM creation, configuration, and execution. The VM runs in a
-/// separate thread; the caller gets back a unix socket for virtio-net
-/// communication.
+/// forked child process; the caller gets back a unix socket for
+/// virtio-net communication.
+///
+/// Fork, not a thread: libkrun's `krun_start_enter` terminates its
+/// process via `libc::_exit` on guest shutdown (`Vmm::stop` in
+/// libkrun's vmm crate), bypassing Rust Drop impls AND atexit handlers.
+/// Running it in a child confines the `_exit` to that child; the parent
+/// reaps the guest exit code with waitpid and cleans up normally. This
+/// is the pattern smolvm uses and the libkrun maintainer endorses until
+/// the 2.0 API adds a returning entry point.
+/// See <https://github.com/libkrun/libkrun/issues/561>
 use std::ffi::CString;
 use std::os::raw::c_char;
 use std::os::unix::io::AsRawFd;
 use std::os::unix::net::UnixStream;
 use std::path::Path;
-use std::thread::JoinHandle;
 
 use crate::ffi;
 
@@ -48,42 +56,113 @@ pub struct VmConfig {
     pub interactive: bool,
 }
 
-/// A running VM. Owns the host end of the virtio-net socket and the VM thread.
+/// A running VM. Owns the host end of the virtio-net socket and the
+/// child process running libkrun.
 pub struct Vm {
     /// Host-side unix socket for virtio-net frame I/O.
     pub net_sock: UnixStream,
-    /// VM thread handle. Note: `krun_start_enter` blocks until the VM is
-    /// destroyed, which may not happen when the guest process exits.
-    /// Joining this thread may block indefinitely.
-    _thread: JoinHandle<i32>,
+    /// PID of the forked child running `krun_start_enter`. The child
+    /// `_exit`s with the guest's exit code on shutdown.
+    child: libc::pid_t,
+}
+
+/// Exit code libkrun reserves for VMM-level errors (see libkrun.h).
+const EXIT_VMM_ERROR: i32 = 125;
+
+/// Decode a waitpid status into a shell-style exit code:
+/// the exit code for normal exits, 128 + signal for signal deaths.
+const fn exit_code_from_wait_status(status: libc::c_int) -> i32 {
+    if libc::WIFEXITED(status) {
+        libc::WEXITSTATUS(status)
+    } else if libc::WIFSIGNALED(status) {
+        128 + libc::WTERMSIG(status)
+    } else {
+        EXIT_VMM_ERROR
+    }
 }
 
 impl Vm {
     /// Boot a VM with the given configuration.
     ///
-    /// Returns immediately with a `Vm` handle. The VM runs in a background thread.
-    /// Use `net_sock` to communicate via smoltcp.
+    /// Forks a child to host libkrun and returns immediately with a `Vm`
+    /// handle. Use `net_sock` to communicate via smoltcp; when the guest
+    /// exits, the child closes its socket end and the peer sees EOF.
+    /// Call `shutdown()` to reap the child and get the guest exit code.
+    ///
+    /// Must be called before the process spawns any threads: the child
+    /// inherits only the calling thread, and a lock held by another
+    /// thread at fork time would deadlock the child.
     #[must_use]
     #[allow(clippy::expect_used, clippy::unwrap_used)] // FFI setup; failures are unrecoverable
     pub fn boot(config: VmConfig) -> Self {
         let (host_sock, guest_sock) = UnixStream::pair().expect("socketpair failed");
         let guest_fd = guest_sock.as_raw_fd();
 
-        let thread = std::thread::spawn(move || {
-            // Catch panics to prevent unwinding across the FFI boundary
-            // into libkrun's C code, which would be undefined behavior.
+        // SAFETY: fork + prctl + getppid are async-signal-safe; the
+        // child does allocate afterwards, which is sound because no
+        // other threads exist yet (see doc comment).
+        let pid = unsafe { libc::fork() };
+        assert!(pid >= 0, "fork failed: {}", std::io::Error::last_os_error());
+
+        if pid == 0 {
+            // Child: this process belongs to libkrun now.
+            unsafe {
+                // Die with the parent so VMs are never orphaned.
+                libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGKILL);
+                // Close the race where the parent died before prctl.
+                if libc::getppid() == 1 {
+                    libc::_exit(EXIT_VMM_ERROR);
+                }
+            }
+            // Close the host end so the parent's proxy sees EOF when
+            // this child dies, not a silently held-open socket.
+            drop(host_sock);
+
+            // Catch panics (krun_check! panics on FFI errors) to avoid
+            // unwinding into the parent's inherited stack frames.
             let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 Self::run_vm(config, guest_sock, guest_fd)
             }));
-            result.unwrap_or_else(|_| {
-                log::error!("VM thread panicked, aborting to prevent UB");
-                std::process::abort();
-            })
-        });
+            // run_vm only returns if krun_start_enter failed pre-boot;
+            // on guest shutdown libkrun _exits this child directly.
+            // _exit, not exit: don't flush stdio buffers inherited from
+            // the parent or run its atexit handlers.
+            let _ = result;
+            unsafe { libc::_exit(EXIT_VMM_ERROR) }
+        }
+
+        // Parent: close the guest end. virtio-net must be the only
+        // holder so EOF propagates when the child exits.
+        drop(guest_sock);
 
         Self {
             net_sock: host_sock,
-            _thread: thread,
+            child: pid,
+        }
+    }
+
+    /// Reap the VM child and return the guest exit code.
+    ///
+    /// If the child is still running (e.g. proxy timeout rather than
+    /// guest exit), kill it first. Blocks until the child is reaped.
+    pub fn shutdown(&self) -> i32 {
+        let mut status: libc::c_int = 0;
+        unsafe {
+            // Fast path: child already exited (the normal case, the
+            // proxy loop breaks on socket EOF after the child dies).
+            let reaped = libc::waitpid(self.child, &raw mut status, libc::WNOHANG);
+            if reaped == self.child {
+                return exit_code_from_wait_status(status);
+            }
+            // Child still alive: kill it. SIGKILL, not SIGTERM; libkrun
+            // has no graceful-shutdown path on Linux and the rootfs is
+            // host-managed, so there's nothing to flush guest-side.
+            libc::kill(self.child, libc::SIGKILL);
+            if libc::waitpid(self.child, &raw mut status, 0) == self.child {
+                exit_code_from_wait_status(status)
+            } else {
+                EXIT_VMM_ERROR
+            }
         }
     }
 
@@ -267,4 +346,31 @@ pub fn install_ca_cert(rootfs: &Path, pem: &str) -> std::io::Result<()> {
 /// the tool doesn't exist.
 pub const fn ca_update_commands() -> &'static str {
     "update-ca-certificates 2>/dev/null; update-ca-trust 2>/dev/null; true"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Linux wait status encoding: normal exit code N is N << 8,
+    // death by signal S is S in the low 7 bits.
+
+    #[test]
+    fn exit_code_zero_from_clean_exit() {
+        assert_eq!(exit_code_from_wait_status(0), 0);
+    }
+
+    #[test]
+    fn exit_code_preserved_from_nonzero_exit() {
+        assert_eq!(exit_code_from_wait_status(42 << 8), 42);
+        assert_eq!(exit_code_from_wait_status(1 << 8), 1);
+        assert_eq!(exit_code_from_wait_status(255 << 8), 255);
+    }
+
+    #[test]
+    fn exit_code_128_plus_signal_when_killed() {
+        assert_eq!(exit_code_from_wait_status(libc::SIGKILL), 137);
+        assert_eq!(exit_code_from_wait_status(libc::SIGTERM), 143);
+        assert_eq!(exit_code_from_wait_status(libc::SIGINT), 130);
+    }
 }


### PR DESCRIPTION
## Summary

- **Guest non-root execution:** Claude Code rejects `--dangerously-skip-permissions` under root, and libkrun runs the guest init as root. New `run_as` field on `AgentDef` wraps the user command with `runuser -u dev -- sh -c '...'`. Network/CA/mount setup still runs as root; only the agent command drops privileges.

- **Browser support (`--browser`):** Launches headless Chrome on the host with CDP access from the guest via port forwarding. Chrome's outbound traffic goes through a lightweight allowlist proxy enforcing the same host restrictions as the main MITM proxy, including SSRF protection for private IPs. Chrome's sandbox stays enabled (it runs on the host, not in the VM). Guest gets `REDAN_BROWSER=1`, `REDAN_BROWSER_HOST`, `REDAN_BROWSER_CDP_PORT` env vars.

- **README revamp:** Merged overlapping sections, added docs for browser support and port forwarding, trimmed verbose limitations into inline notes. 624 -> 389 lines.

## What's in each commit

1. `feat(exec)`: `run_as` field, `wrap_run_as()`, `runuser` wrapping, HOME env, plumbing through ExecArgs/DaemonConfig
2. `feat(browser)`: `browser.rs` (Chrome discovery, lifecycle, allowlist proxy, 18 tests), `--browser` flag, doctor check, `is_private_ip` made pub
3. `docs(readme)`: full revamp

## Test plan

- [x] `mise run check` passes (176 tests, clippy clean, format clean)
- [x] `redan exec` with Claude Code image: agent starts without "cannot be used with root" error
- [x] `redan exec --browser`: Chrome launches, CDP accessible from guest, cleanup on exit
- [x] `redan doctor`: shows Chrome status
- [x] Verify allowlist proxy blocks non-allowlisted hosts through Chrome
- [x] Verify Chrome profile dir removed and process killed on exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Host-launched headless browser with CDP access, proxy allowlist and automatic guest port forwarding
  * Run guests/agents as an unprivileged guest user with pre-boot staging of credential files
  * image import supports --force

* **CLI Changes**
  * exec accepts an optional single shell command (-c/--command), a run-as option, and a --browser flag
  * exec now returns the guest exit code

* **Documentation**
  * Major README overhaul: onboarding, agent/image examples, secrets, networking, and browser guidance

* **Diagnostics**
  * doctor reports Chrome/Chromium availability
<!-- end of auto-generated comment: release notes by coderabbit.ai -->