### PR TITLE
feat: `redan run <agent>` opinionated profile launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,18 +70,19 @@ cargo install --git https://github.com/getredan/redan.git
 redan doctor
 ```
 
-## Claude Code (zero-config)
+## Run an agent (zero-config)
 
 ```bash
 export ANTHROPIC_API_KEY=sk-ant-...
 cd ~/my-project
-redan exec
+redan run claude
 ```
 
-That's it. Redan auto-detects Claude Code: picks up your API key,
-builds the `claude-code` image if needed, mounts the current directory,
-allows Anthropic's API hosts, and drops you into an interactive session.
-It prints what it chose so nothing is silent:
+That's it. `redan run claude` picks up your API key, builds the
+`claude-code` image if needed, mounts the current directory, allows
+Anthropic's API hosts, drops privileges to a non-root user, and drops
+you into an interactive Claude Code session. It prints what it chose so
+nothing is silent:
 
 ```text
   Using image: claude-code
@@ -89,14 +90,21 @@ It prints what it chose so nothing is silent:
   Mounting current directory → /workspace
 ```
 
-Git remote hosts are added to the network allowlist automatically so
-git push/pull works out of the box. The agent runs as an unprivileged
-user inside the VM (not root), matching how Claude Code expects to
-operate.
+`redan run pi` does the same for Pi. Run `redan run` with no agent to
+auto-detect from the environment. Pass an initial prompt after `--`:
 
-Auto-detect kicks in when there's no `redan.toml` and no explicit CLI
-flags. For OAuth-based auth (Claude Max/Team/Enterprise), redan detects
-your `~/.claude` credentials and stages them into the VM instead.
+```bash
+redan run claude -- "fix the failing test in api/users.py"
+```
+
+Git remote hosts are added to the network allowlist automatically so
+git push/pull works out of the box. For OAuth auth (Claude Max/Team/
+Enterprise), redan detects your `~/.claude` credentials and stages them
+into the VM instead of reading an API key.
+
+`redan run` is the opinionated path: it knows each agent's image,
+command, auth, and network policy. For full manual control over the
+image and command, use `redan exec` (below).
 
 ## Any agent
 
@@ -108,7 +116,7 @@ redan image create myimage --packages "python3 nodejs npm"
 redan exec --image myimage \
   --secret "API_KEY=env://MY_API_KEY:api.example.com" \
   --mount ./my-project \
-  -- my-agent --some-flag
+  -c "my-agent --some-flag"
 ```
 
 Or use `redan.toml` for repeatable setups:
@@ -186,7 +194,9 @@ match TLS SNI.
 **Discover mode** lets you figure out what hosts the agent needs:
 
 ```bash
-redan exec --discover -- my-agent --some-flag
+redan run claude --discover
+# or, for a custom image:
+redan exec --image myimage --discover -c "my-agent --some-flag"
 ```
 
 Redan allows all connections, prints the observed hosts at exit, and
@@ -358,9 +368,9 @@ No Windows support (WSL2 with KVM passthrough may work, untested).
 
 ## Status
 
-Alpha. The full chain works end-to-end: zero-config `redan exec` through
-interactive Claude Code sessions with network policy enforcement, credential
-staging, and privilege separation. Pre-built binaries on
+Alpha. The full chain works end-to-end: zero-config `redan run claude`
+through interactive Claude Code sessions with network policy enforcement,
+credential staging, and privilege separation. Pre-built binaries on
 [GitHub Releases](https://github.com/getredan/redan/releases).
 
 This code has not been through an independent security audit. Use at

--- a/dockerfiles/claude-code.dockerfile
+++ b/dockerfiles/claude-code.dockerfile
@@ -18,9 +18,11 @@ RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_MAJOR}.x | bash - && \
     apt-get install -y -qq --no-install-recommends nodejs && \
     rm -rf /var/lib/apt/lists/*
 
-# Claude Code, plus a CDP client so `--browser` tasks can drive Chrome
-# without hand-rolling a WebSocket client.
-RUN npm install -g @anthropic-ai/claude-code chrome-remote-interface
+# Claude Code, plus WebSocket/CDP clients so `--browser` tasks can drive
+# Chrome without reinventing a WebSocket from raw sockets. `ws` is what
+# agents reach for by default; chrome-remote-interface is the higher-level
+# CDP client. Both global; NODE_PATH (set by redan) makes them require-able.
+RUN npm install -g @anthropic-ai/claude-code ws chrome-remote-interface
 
 # Non-root user (ubuntu:24.04 ships with ubuntu:1000, remove it first)
 RUN userdel -r ubuntu 2>/dev/null; \

--- a/dockerfiles/claude-code.dockerfile
+++ b/dockerfiles/claude-code.dockerfile
@@ -1,8 +1,15 @@
 FROM ubuntu:24.04
 
+# Base toolset agents commonly reach for. The sandbox is default-deny
+# egress, so the agent can't apt/pip/npm-install at runtime; tools have to
+# be here at build time. No build-essential: compilation-heavy work belongs
+# in a custom image (redan image import, or a devcontainer).
 RUN apt-get update -qq && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends \
-      ca-certificates curl git iproute2 && \
+      ca-certificates curl wget git iproute2 openssh-client gnupg \
+      ripgrep fd-find jq unzip less vim procps tmux \
+      python3 python3-pip && \
+    ln -sf "$(command -v fdfind)" /usr/local/bin/fd && \
     rm -rf /var/lib/apt/lists/*
 
 # Node.js via NodeSource (Ubuntu 24.04 ships Node 18, which is EOL)
@@ -11,8 +18,9 @@ RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_MAJOR}.x | bash - && \
     apt-get install -y -qq --no-install-recommends nodejs && \
     rm -rf /var/lib/apt/lists/*
 
-# Claude Code
-RUN npm install -g @anthropic-ai/claude-code
+# Claude Code, plus a CDP client so `--browser` tasks can drive Chrome
+# without hand-rolling a WebSocket client.
+RUN npm install -g @anthropic-ai/claude-code chrome-remote-interface
 
 # Non-root user (ubuntu:24.04 ships with ubuntu:1000, remove it first)
 RUN userdel -r ubuntu 2>/dev/null; \

--- a/dockerfiles/pi.dockerfile
+++ b/dockerfiles/pi.dockerfile
@@ -1,8 +1,15 @@
 FROM ubuntu:24.04
 
+# Base toolset agents commonly reach for. The sandbox is default-deny
+# egress, so the agent can't apt/pip/npm-install at runtime; tools have to
+# be here at build time. No build-essential: compilation-heavy work belongs
+# in a custom image (redan image import, or a devcontainer).
 RUN apt-get update -qq && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends \
-      ca-certificates curl git iproute2 && \
+      ca-certificates curl wget git iproute2 openssh-client gnupg \
+      ripgrep fd-find jq unzip less vim procps tmux \
+      python3 python3-pip && \
+    ln -sf "$(command -v fdfind)" /usr/local/bin/fd && \
     rm -rf /var/lib/apt/lists/*
 
 # Node.js via NodeSource
@@ -11,8 +18,9 @@ RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_MAJOR}.x | bash - && \
     apt-get install -y -qq --no-install-recommends nodejs && \
     rm -rf /var/lib/apt/lists/*
 
-# Pi coding agent
-RUN npm install -g @earendil-works/pi-coding-agent
+# Pi coding agent, plus a CDP client so `--browser` tasks can drive Chrome
+# without hand-rolling a WebSocket client.
+RUN npm install -g @earendil-works/pi-coding-agent chrome-remote-interface
 
 # Non-root user (ubuntu:24.04 ships with ubuntu:1000, remove it first)
 RUN userdel -r ubuntu 2>/dev/null; \

--- a/dockerfiles/pi.dockerfile
+++ b/dockerfiles/pi.dockerfile
@@ -18,9 +18,11 @@ RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_MAJOR}.x | bash - && \
     apt-get install -y -qq --no-install-recommends nodejs && \
     rm -rf /var/lib/apt/lists/*
 
-# Pi coding agent, plus a CDP client so `--browser` tasks can drive Chrome
-# without hand-rolling a WebSocket client.
-RUN npm install -g @earendil-works/pi-coding-agent chrome-remote-interface
+# Pi coding agent, plus WebSocket/CDP clients so `--browser` tasks can
+# drive Chrome without reinventing a WebSocket from raw sockets. `ws` is
+# what agents reach for by default; chrome-remote-interface is the
+# higher-level CDP client. NODE_PATH (set by redan) makes them require-able.
+RUN npm install -g @earendil-works/pi-coding-agent ws chrome-remote-interface
 
 # Non-root user (ubuntu:24.04 ships with ubuntu:1000, remove it first)
 RUN userdel -r ubuntu 2>/dev/null; \

--- a/src/auto_detect.rs
+++ b/src/auto_detect.rs
@@ -38,11 +38,22 @@ static CLAUDE_CODE: AgentDef = AgentDef {
     timeout_secs: 3600,
     run_as: Some("dev"),
     guest_env: &[("HOME", "/home/dev")],
-    api_key: Some(ApiKeyDef {
-        env_var: "ANTHROPIC_API_KEY",
-        inject_hosts: &["api.anthropic.com"],
-        guest_env: &[("CLAUDE_CONFIG_DIR", "/workspace/.claude")],
-    }),
+    // ANTHROPIC_API_KEY first to match Claude Code's own auth precedence
+    // (API key over OAuth token). CLAUDE_CODE_OAUTH_TOKEN is the reliable
+    // subscription path for sandboxes: a 1-year token from `claude
+    // setup-token`. Both beat staging .credentials.json, which goes stale.
+    env_auth: &[
+        EnvAuthDef {
+            env_var: "ANTHROPIC_API_KEY",
+            inject_hosts: &["api.anthropic.com"],
+            guest_env: &[("CLAUDE_CONFIG_DIR", "/workspace/.claude")],
+        },
+        EnvAuthDef {
+            env_var: "CLAUDE_CODE_OAUTH_TOKEN",
+            inject_hosts: &["api.anthropic.com"],
+            guest_env: &[("CLAUDE_CONFIG_DIR", "/workspace/.claude")],
+        },
+    ],
     stored_credentials: Some(StoredCredentialsDef {
         home_dir: ".claude",
         credentials_file: ".credentials.json",
@@ -63,11 +74,11 @@ static PI: AgentDef = AgentDef {
     timeout_secs: 3600,
     run_as: Some("dev"),
     guest_env: &[("HOME", "/home/dev")],
-    api_key: Some(ApiKeyDef {
+    env_auth: &[EnvAuthDef {
         env_var: "ANTHROPIC_API_KEY",
         inject_hosts: &["api.anthropic.com"],
         guest_env: &[],
-    }),
+    }],
     stored_credentials: Some(StoredCredentialsDef {
         home_dir: ".pi/agent",
         credentials_file: "auth.json",
@@ -98,14 +109,17 @@ pub struct AgentDef {
     pub run_as: Option<&'static str>,
     /// Extra guest env vars (set regardless of auth method).
     pub guest_env: &'static [(&'static str, &'static str)],
-    /// API-key-based auth (tried first).
-    pub api_key: Option<ApiKeyDef>,
-    /// Stored credentials auth (fallback when no API key).
+    /// Env-var auth methods, tried in order (first one set wins).
+    /// Tried before stored-credential staging.
+    pub env_auth: &'static [EnvAuthDef],
+    /// Stored credentials auth (fallback when no env-var auth is set).
     pub stored_credentials: Option<StoredCredentialsDef>,
 }
 
-/// Auth via an environment variable injected as a redan secret.
-pub struct ApiKeyDef {
+/// Auth via a host environment variable injected as a redan secret.
+/// Covers both API keys (`ANTHROPIC_API_KEY`) and long-lived OAuth tokens
+/// (`CLAUDE_CODE_OAUTH_TOKEN` from `claude setup-token`).
+pub struct EnvAuthDef {
     /// Host env var to read (e.g., `ANTHROPIC_API_KEY`).
     pub env_var: &'static str,
     /// Hosts the secret is injected into.
@@ -161,8 +175,11 @@ pub struct DetectedAgent {
 
 /// The auth method that was actually found in the environment.
 pub enum ResolvedAuth {
-    ApiKey,
-    StoredCredentials { host_config_dir: PathBuf },
+    /// A host env var (API key or OAuth token) is set and will be injected.
+    EnvVar(&'static EnvAuthDef),
+    StoredCredentials {
+        host_config_dir: PathBuf,
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -213,16 +230,25 @@ pub fn resolve_by_slug(slug: &str) -> Result<AutoDetected, ResolveError> {
 /// Probe a single agent's auth requirements against the current environment.
 fn detect_one(agent: &'static AgentDef) -> Option<DetectedAgent> {
     let home = std::env::var("HOME").ok();
-    let api_key_val = agent
-        .api_key
-        .as_ref()
-        .and_then(|a| std::env::var(a.env_var).ok());
+    let env_match = match_env_auth(agent, |var| std::env::var(var).ok());
     let oauth_creds = home.as_ref().and_then(|h| {
         let sc = agent.stored_credentials.as_ref()?;
         let path = Path::new(h).join(sc.home_dir).join(sc.credentials_file);
         path.exists().then_some(path)
     });
-    probe_with_env(agent, api_key_val.as_deref(), oauth_creds.as_deref(), None)
+    probe_with_env(agent, env_match, oauth_creds.as_deref(), None)
+}
+
+/// The first of the agent's env-var auth methods whose variable is set to a
+/// non-empty value. `lookup` reads an env var (injected in tests).
+fn match_env_auth(
+    agent: &'static AgentDef,
+    lookup: impl Fn(&str) -> Option<String>,
+) -> Option<&'static EnvAuthDef> {
+    agent
+        .env_auth
+        .iter()
+        .find(|e| lookup(e.env_var).is_some_and(|v| !v.trim().is_empty()))
 }
 
 // ---------------------------------------------------------------------------
@@ -257,22 +283,20 @@ pub const fn has_explicit_flags(f: &ExecFlags<'_>) -> bool {
 // ---------------------------------------------------------------------------
 
 /// Check whether an agent's auth requirements are met.
-/// API key is tried first; OAuth is the fallback.
+/// Env-var auth (`env_match`) is tried first; stored credentials are the
+/// fallback.
 fn probe_with_env(
     agent: &'static AgentDef,
-    api_key_value: Option<&str>,
+    env_match: Option<&'static EnvAuthDef>,
     oauth_credentials: Option<&Path>,
     has_image: Option<bool>,
 ) -> Option<DetectedAgent> {
     let image_exists = has_image.unwrap_or_else(|| image_exists(agent.image));
 
-    if agent.api_key.is_some()
-        && let Some(key) = api_key_value
-        && !key.trim().is_empty()
-    {
+    if let Some(def) = env_match {
         return Some(DetectedAgent {
             agent,
-            auth: ResolvedAuth::ApiKey,
+            auth: ResolvedAuth::EnvVar(def),
             image_exists,
         });
     }
@@ -302,23 +326,21 @@ fn apply_auth(
     allow: &mut Vec<String>,
 ) {
     match auth {
-        ResolvedAuth::ApiKey => {
-            if let Some(api) = agent.api_key.as_ref() {
-                messages.push(format!(
-                    "Injecting {} for {}",
-                    api.env_var,
-                    api.inject_hosts.join(", ")
-                ));
-                config.secrets.insert(
-                    api.env_var.into(),
-                    SecretConfig {
-                        value: format!("env://{}", api.env_var),
-                        hosts: api.inject_hosts.iter().map(|&h| h.into()).collect(),
-                    },
-                );
-                for &(key, val) in api.guest_env {
-                    config.env.insert(key.into(), val.into());
-                }
+        ResolvedAuth::EnvVar(def) => {
+            messages.push(format!(
+                "Injecting {} for {}",
+                def.env_var,
+                def.inject_hosts.join(", ")
+            ));
+            config.secrets.insert(
+                def.env_var.into(),
+                SecretConfig {
+                    value: format!("env://{}", def.env_var),
+                    hosts: def.inject_hosts.iter().map(|&h| h.into()).collect(),
+                },
+            );
+            for &(key, val) in def.guest_env {
+                config.env.insert(key.into(), val.into());
             }
         }
         ResolvedAuth::StoredCredentials { host_config_dir } => {
@@ -485,11 +507,17 @@ fn host_from_remote_url(url: &str) -> Option<String> {
 mod tests {
     use super::*;
 
+    /// One of an agent's env-var auth defs, by variable name (test helper).
+    fn env_def(agent: &'static AgentDef, var: &str) -> Option<&'static EnvAuthDef> {
+        agent.env_auth.iter().find(|e| e.env_var == var)
+    }
+
     #[test]
     fn detect_api_key_produces_correct_config() {
-        let detected = probe_with_env(&CLAUDE_CODE, Some("sk-ant-test123"), None, Some(true))
-            .expect("should detect via API key");
-        assert!(matches!(detected.auth, ResolvedAuth::ApiKey));
+        let api = env_def(&CLAUDE_CODE, "ANTHROPIC_API_KEY");
+        let detected =
+            probe_with_env(&CLAUDE_CODE, api, None, Some(true)).expect("should detect via API key");
+        assert!(matches!(detected.auth, ResolvedAuth::EnvVar(_)));
 
         let auto = build_config(&detected);
         assert_eq!(auto.config.image.as_deref(), Some("claude-code"));
@@ -583,9 +611,10 @@ mod tests {
         let creds = tmp.join(".credentials.json");
         std::fs::write(&creds, "{}").unwrap();
 
-        let detected = probe_with_env(&CLAUDE_CODE, Some("sk-ant-test"), Some(&creds), Some(true))
-            .expect("should detect");
-        assert!(matches!(detected.auth, ResolvedAuth::ApiKey));
+        let api = env_def(&CLAUDE_CODE, "ANTHROPIC_API_KEY");
+        let detected =
+            probe_with_env(&CLAUDE_CODE, api, Some(&creds), Some(true)).expect("should detect");
+        assert!(matches!(detected.auth, ResolvedAuth::EnvVar(_)));
 
         let auto = build_config(&detected);
         assert!(auto.config.secrets.contains_key("ANTHROPIC_API_KEY"));
@@ -600,13 +629,52 @@ mod tests {
     }
 
     #[test]
+    fn match_env_auth_prefers_api_key_over_oauth_token() {
+        // Both set -> API key wins (matches Claude Code's own precedence).
+        let m = match_env_auth(&CLAUDE_CODE, |_| Some("value".into()));
+        assert_eq!(m.map(|e| e.env_var), Some("ANTHROPIC_API_KEY"));
+    }
+
+    #[test]
+    fn match_env_auth_falls_to_oauth_token_when_only_it_is_set() {
+        let m = match_env_auth(&CLAUDE_CODE, |var| {
+            (var == "CLAUDE_CODE_OAUTH_TOKEN").then(|| "tok".into())
+        });
+        assert_eq!(m.map(|e| e.env_var), Some("CLAUDE_CODE_OAUTH_TOKEN"));
+    }
+
+    #[test]
+    fn match_env_auth_ignores_empty_values() {
+        let m = match_env_auth(&CLAUDE_CODE, |var| {
+            (var == "ANTHROPIC_API_KEY").then(|| "  ".into())
+        });
+        assert!(m.is_none());
+    }
+
+    #[test]
+    fn oauth_token_injects_as_secret() {
+        let oauth = env_def(&CLAUDE_CODE, "CLAUDE_CODE_OAUTH_TOKEN");
+        let detected = probe_with_env(&CLAUDE_CODE, oauth, None, Some(true))
+            .expect("should detect via OAuth token");
+        let auto = build_config(&detected);
+        let secret = auto.config.secrets.get("CLAUDE_CODE_OAUTH_TOKEN").unwrap();
+        assert_eq!(secret.value, "env://CLAUDE_CODE_OAUTH_TOKEN");
+        assert_eq!(secret.hosts, vec!["api.anthropic.com"]);
+        // No credentials file staged when an env token is present.
+        assert!(auto.stage_files.is_empty());
+    }
+
+    #[test]
     fn empty_api_key_falls_through_to_oauth() {
         let tmp = std::env::temp_dir().join("redan-test-empty-key");
         let _ = std::fs::create_dir_all(&tmp);
         let creds = tmp.join(".credentials.json");
         std::fs::write(&creds, "{}").unwrap();
 
-        let detected = probe_with_env(&CLAUDE_CODE, Some(""), Some(&creds), Some(true))
+        // Empty env vars don't match; fall back to staged credentials.
+        let env_match = match_env_auth(&CLAUDE_CODE, |_| Some(String::new()));
+        assert!(env_match.is_none());
+        let detected = probe_with_env(&CLAUDE_CODE, env_match, Some(&creds), Some(true))
             .expect("should fall through to OAuth");
         assert!(matches!(
             detected.auth,
@@ -618,13 +686,14 @@ mod tests {
 
     #[test]
     fn empty_api_key_no_oauth_returns_none() {
-        assert!(probe_with_env(&CLAUDE_CODE, Some("  "), None, Some(true)).is_none());
+        let env_match = match_env_auth(&CLAUDE_CODE, |_| Some("  ".into()));
+        assert!(probe_with_env(&CLAUDE_CODE, env_match, None, Some(true)).is_none());
     }
 
     #[test]
     fn needs_image_build_when_image_missing() {
-        let detected = probe_with_env(&CLAUDE_CODE, Some("sk-ant-test"), None, Some(false))
-            .expect("should detect");
+        let api = env_def(&CLAUDE_CODE, "ANTHROPIC_API_KEY");
+        let detected = probe_with_env(&CLAUDE_CODE, api, None, Some(false)).expect("should detect");
         let auto = build_config(&detected);
         assert!(auto.needs_image_build);
         assert!(auto.messages.iter().any(|m| m.contains("will build")));
@@ -632,9 +701,10 @@ mod tests {
 
     #[test]
     fn pi_api_key_produces_correct_config() {
-        let detected = probe_with_env(&PI, Some("sk-ant-test123"), None, Some(true))
-            .expect("should detect Pi via API key");
-        assert!(matches!(detected.auth, ResolvedAuth::ApiKey));
+        let api = env_def(&PI, "ANTHROPIC_API_KEY");
+        let detected =
+            probe_with_env(&PI, api, None, Some(true)).expect("should detect Pi via API key");
+        assert!(matches!(detected.auth, ResolvedAuth::EnvVar(_)));
 
         let auto = build_config(&detected);
         assert_eq!(auto.config.image.as_deref(), Some("pi"));

--- a/src/auto_detect.rs
+++ b/src/auto_detect.rs
@@ -42,26 +42,26 @@ static CLAUDE_CODE: AgentDef = AgentDef {
     // (API key over OAuth token). CLAUDE_CODE_OAUTH_TOKEN is the reliable
     // subscription path for sandboxes: a 1-year token from `claude
     // setup-token`. Both beat staging .credentials.json, which goes stale.
-    env_auth: &[
-        EnvAuthDef {
+    auth: &[
+        AuthMethod::EnvSecret {
             env_var: "ANTHROPIC_API_KEY",
-            inject_hosts: &["api.anthropic.com"],
+            hosts: &["api.anthropic.com"],
             guest_env: &[("CLAUDE_CONFIG_DIR", "/workspace/.claude")],
         },
-        EnvAuthDef {
+        AuthMethod::EnvSecret {
             env_var: "CLAUDE_CODE_OAUTH_TOKEN",
-            inject_hosts: &["api.anthropic.com"],
+            hosts: &["api.anthropic.com"],
             guest_env: &[("CLAUDE_CONFIG_DIR", "/workspace/.claude")],
+        },
+        AuthMethod::StagedFiles {
+            dir: ".claude",
+            probe: ".credentials.json",
+            files: &[".credentials.json"],
+            guest_dir: "/tmp/.claude",
+            hosts: &["auth.anthropic.com", "console.anthropic.com"],
+            guest_env: &[("CLAUDE_CONFIG_DIR", "/tmp/.claude")],
         },
     ],
-    stored_credentials: Some(StoredCredentialsDef {
-        home_dir: ".claude",
-        credentials_file: ".credentials.json",
-        stage_files: &[".credentials.json"],
-        guest_dir: "/tmp/.claude",
-        guest_env: &[("CLAUDE_CONFIG_DIR", "/tmp/.claude")],
-        extra_hosts: &["auth.anthropic.com", "console.anthropic.com"],
-    }),
 };
 
 static PI: AgentDef = AgentDef {
@@ -74,19 +74,21 @@ static PI: AgentDef = AgentDef {
     timeout_secs: 3600,
     run_as: Some("dev"),
     guest_env: &[("HOME", "/home/dev")],
-    env_auth: &[EnvAuthDef {
-        env_var: "ANTHROPIC_API_KEY",
-        inject_hosts: &["api.anthropic.com"],
-        guest_env: &[],
-    }],
-    stored_credentials: Some(StoredCredentialsDef {
-        home_dir: ".pi/agent",
-        credentials_file: "auth.json",
-        stage_files: &["auth.json", "settings.json", "models.json"],
-        guest_dir: "/home/dev/.pi/agent",
-        guest_env: &[],
-        extra_hosts: &[],
-    }),
+    auth: &[
+        AuthMethod::EnvSecret {
+            env_var: "ANTHROPIC_API_KEY",
+            hosts: &["api.anthropic.com"],
+            guest_env: &[],
+        },
+        AuthMethod::StagedFiles {
+            dir: ".pi/agent",
+            probe: "auth.json",
+            files: &["auth.json", "settings.json", "models.json"],
+            guest_dir: "/home/dev/.pi/agent",
+            hosts: &[],
+            guest_env: &[],
+        },
+    ],
 };
 
 // ---------------------------------------------------------------------------
@@ -109,43 +111,43 @@ pub struct AgentDef {
     pub run_as: Option<&'static str>,
     /// Extra guest env vars (set regardless of auth method).
     pub guest_env: &'static [(&'static str, &'static str)],
-    /// Env-var auth methods, tried in order (first one set wins).
-    /// Tried before stored-credential staging.
-    pub env_auth: &'static [EnvAuthDef],
-    /// Stored credentials auth (fallback when no env-var auth is set).
-    pub stored_credentials: Option<StoredCredentialsDef>,
+    /// Credential supply methods, in priority order. The first method
+    /// whose source is present (env var set, probe file exists) is used.
+    pub auth: &'static [AuthMethod],
 }
 
-/// Auth via a host environment variable injected as a redan secret.
-/// Covers both API keys (`ANTHROPIC_API_KEY`) and long-lived OAuth tokens
-/// (`CLAUDE_CODE_OAUTH_TOKEN` from `claude setup-token`).
-pub struct EnvAuthDef {
-    /// Host env var to read (e.g., `ANTHROPIC_API_KEY`).
-    pub env_var: &'static str,
-    /// Hosts the secret is injected into.
-    pub inject_hosts: &'static [&'static str],
-    /// Guest env vars to set when using this auth path.
-    pub guest_env: &'static [(&'static str, &'static str)],
-}
-
-/// Auth via credentials stored in a config directory on the host.
-///
-/// Files are staged into the guest rootfs before boot (same pattern
-/// as CA cert installation), so no mount or runtime copy is needed.
-pub struct StoredCredentialsDef {
-    /// Config directory relative to `$HOME` (e.g., `.claude`).
-    pub home_dir: &'static str,
-    /// File that signals credentials exist (e.g., `.credentials.json`).
-    pub credentials_file: &'static str,
-    /// Files to stage from `home_dir` into the guest.
-    /// If empty, only `credentials_file` is staged.
-    pub stage_files: &'static [&'static str],
-    /// Guest directory to stage files into.
-    pub guest_dir: &'static str,
-    /// Guest env vars to set when using this auth path.
-    pub guest_env: &'static [(&'static str, &'static str)],
-    /// Extra network hosts for token exchange.
-    pub extra_hosts: &'static [&'static str],
+/// One way to supply an agent's credential.
+pub enum AuthMethod {
+    /// A host env var injected as a redan secret. The real value never
+    /// enters the guest: a placeholder is set inside, the proxy swaps in
+    /// the real value for requests to `hosts` and scrubs it from
+    /// responses. Present when the env var is set to a non-empty value.
+    /// Covers API keys (`ANTHROPIC_API_KEY`) and long-lived OAuth tokens
+    /// (`CLAUDE_CODE_OAUTH_TOKEN` from `claude setup-token`).
+    EnvSecret {
+        env_var: &'static str,
+        /// Hosts the secret is injected into (and allowed).
+        hosts: &'static [&'static str],
+        /// Guest env vars to set when this method is used.
+        guest_env: &'static [(&'static str, &'static str)],
+    },
+    /// Credential files staged from `$HOME/dir` into the guest rootfs
+    /// (same pattern as CA cert install). The real files enter the guest
+    /// as plaintext. Present when `probe` exists under `$HOME/dir`.
+    StagedFiles {
+        /// Config dir relative to `$HOME` (e.g. `.claude`).
+        dir: &'static str,
+        /// File whose existence signals this method applies.
+        probe: &'static str,
+        /// Files to stage from `dir`. Empty stages just `probe`.
+        files: &'static [&'static str],
+        /// Guest directory to stage files into.
+        guest_dir: &'static str,
+        /// Extra hosts to allow (e.g. token-exchange endpoints).
+        hosts: &'static [&'static str],
+        /// Guest env vars to set when this method is used.
+        guest_env: &'static [(&'static str, &'static str)],
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -173,13 +175,11 @@ pub struct DetectedAgent {
     pub image_exists: bool,
 }
 
-/// The auth method that was actually found in the environment.
-pub enum ResolvedAuth {
-    /// A host env var (API key or OAuth token) is set and will be injected.
-    EnvVar(&'static EnvAuthDef),
-    StoredCredentials {
-        host_config_dir: PathBuf,
-    },
+/// The auth method that resolved against the environment.
+pub struct ResolvedAuth {
+    pub method: &'static AuthMethod,
+    /// For `StagedFiles`, the host dir the probe was found in.
+    pub host_dir: Option<PathBuf>,
 }
 
 // ---------------------------------------------------------------------------
@@ -230,25 +230,44 @@ pub fn resolve_by_slug(slug: &str) -> Result<AutoDetected, ResolveError> {
 /// Probe a single agent's auth requirements against the current environment.
 fn detect_one(agent: &'static AgentDef) -> Option<DetectedAgent> {
     let home = std::env::var("HOME").ok();
-    let env_match = match_env_auth(agent, |var| std::env::var(var).ok());
-    let oauth_creds = home.as_ref().and_then(|h| {
-        let sc = agent.stored_credentials.as_ref()?;
-        let path = Path::new(h).join(sc.home_dir).join(sc.credentials_file);
-        path.exists().then_some(path)
-    });
-    probe_with_env(agent, env_match, oauth_creds.as_deref(), None)
+    let auth = resolve_auth(
+        agent,
+        |var| std::env::var(var).ok(),
+        home.as_deref().map(Path::new),
+    )?;
+    Some(DetectedAgent {
+        agent,
+        auth,
+        image_exists: image_exists(agent.image),
+    })
 }
 
-/// The first of the agent's env-var auth methods whose variable is set to a
-/// non-empty value. `lookup` reads an env var (injected in tests).
-fn match_env_auth(
+/// The agent's first available auth method: the first `EnvSecret` whose
+/// env var is set to a non-empty value, or the first `StagedFiles` whose
+/// probe file exists under `$HOME`. `env` reads an env var and `home` is
+/// `$HOME` (both injected in tests).
+fn resolve_auth(
     agent: &'static AgentDef,
-    lookup: impl Fn(&str) -> Option<String>,
-) -> Option<&'static EnvAuthDef> {
-    agent
-        .env_auth
-        .iter()
-        .find(|e| lookup(e.env_var).is_some_and(|v| !v.trim().is_empty()))
+    env: impl Fn(&str) -> Option<String>,
+    home: Option<&Path>,
+) -> Option<ResolvedAuth> {
+    agent.auth.iter().find_map(|method| match method {
+        AuthMethod::EnvSecret { env_var, .. } => {
+            env(env_var)
+                .filter(|v| !v.trim().is_empty())
+                .map(|_| ResolvedAuth {
+                    method,
+                    host_dir: None,
+                })
+        }
+        AuthMethod::StagedFiles { dir, probe, .. } => {
+            let dir = home?.join(dir);
+            dir.join(probe).exists().then_some(ResolvedAuth {
+                method,
+                host_dir: Some(dir),
+            })
+        }
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -282,92 +301,63 @@ pub const fn has_explicit_flags(f: &ExecFlags<'_>) -> bool {
 // Internal: probing and config building
 // ---------------------------------------------------------------------------
 
-/// Check whether an agent's auth requirements are met.
-/// Env-var auth (`env_match`) is tried first; stored credentials are the
-/// fallback.
-fn probe_with_env(
-    agent: &'static AgentDef,
-    env_match: Option<&'static EnvAuthDef>,
-    oauth_credentials: Option<&Path>,
-    has_image: Option<bool>,
-) -> Option<DetectedAgent> {
-    let image_exists = has_image.unwrap_or_else(|| image_exists(agent.image));
-
-    if let Some(def) = env_match {
-        return Some(DetectedAgent {
-            agent,
-            auth: ResolvedAuth::EnvVar(def),
-            image_exists,
-        });
-    }
-
-    if agent.stored_credentials.is_some()
-        && let Some(creds_path) = oauth_credentials
-    {
-        let config_dir = creds_path.parent().unwrap_or(creds_path).to_path_buf();
-        return Some(DetectedAgent {
-            agent,
-            auth: ResolvedAuth::StoredCredentials {
-                host_config_dir: config_dir,
-            },
-            image_exists,
-        });
-    }
-
-    None
-}
-
 fn apply_auth(
-    agent: &AgentDef,
     auth: &ResolvedAuth,
     config: &mut Config,
     messages: &mut Vec<String>,
     stage_files: &mut Vec<(PathBuf, String, String)>,
     allow: &mut Vec<String>,
 ) {
-    match auth {
-        ResolvedAuth::EnvVar(def) => {
-            messages.push(format!(
-                "Injecting {} for {}",
-                def.env_var,
-                def.inject_hosts.join(", ")
-            ));
+    match auth.method {
+        AuthMethod::EnvSecret {
+            env_var,
+            hosts,
+            guest_env,
+        } => {
+            messages.push(format!("Injecting {env_var} for {}", hosts.join(", ")));
             config.secrets.insert(
-                def.env_var.into(),
+                (*env_var).into(),
                 SecretConfig {
-                    value: format!("env://{}", def.env_var),
-                    hosts: def.inject_hosts.iter().map(|&h| h.into()).collect(),
+                    value: format!("env://{env_var}"),
+                    hosts: hosts.iter().map(|&h| h.into()).collect(),
                 },
             );
-            for &(key, val) in def.guest_env {
+            for &(key, val) in *guest_env {
                 config.env.insert(key.into(), val.into());
             }
         }
-        ResolvedAuth::StoredCredentials { host_config_dir } => {
-            if let Some(sc) = agent.stored_credentials.as_ref() {
-                let files_to_stage = if sc.stage_files.is_empty() {
-                    vec![sc.credentials_file]
-                } else {
-                    sc.stage_files.to_vec()
-                };
-                for filename in &files_to_stage {
-                    let host_path = host_config_dir.join(filename);
-                    if host_path.exists() {
-                        messages.push(format!(
-                            "Staging {} → {}/{}",
-                            host_path.display(),
-                            sc.guest_dir,
-                            filename
-                        ));
-                        stage_files.push((host_path, sc.guest_dir.into(), (*filename).into()));
-                    }
+        AuthMethod::StagedFiles {
+            probe,
+            files,
+            guest_dir,
+            hosts,
+            guest_env,
+            ..
+        } => {
+            // host_dir is set by resolve_auth for StagedFiles.
+            let Some(host_dir) = auth.host_dir.as_ref() else {
+                return;
+            };
+            let to_stage: Vec<&str> = if files.is_empty() {
+                vec![probe]
+            } else {
+                files.to_vec()
+            };
+            for filename in to_stage {
+                let host_path = host_dir.join(filename);
+                if host_path.exists() {
+                    messages.push(format!(
+                        "Staging {} → {guest_dir}/{filename}",
+                        host_path.display()
+                    ));
+                    stage_files.push((host_path, (*guest_dir).into(), filename.into()));
                 }
-                for &(key, val) in sc.guest_env {
-                    config.env.insert(key.into(), val.into());
-                }
-                for &host in sc.extra_hosts {
-                    allow.push(host.to_string());
-                }
+            }
+            for &(key, val) in *guest_env {
+                config.env.insert(key.into(), val.into());
+            }
+            for &host in *hosts {
+                allow.push(host.to_string());
             }
         }
     }
@@ -404,7 +394,6 @@ fn build_config(detected: &DetectedAgent) -> AutoDetected {
     }
 
     apply_auth(
-        agent,
         &detected.auth,
         &mut config,
         &mut messages,
@@ -507,17 +496,43 @@ fn host_from_remote_url(url: &str) -> Option<String> {
 mod tests {
     use super::*;
 
-    /// One of an agent's env-var auth defs, by variable name (test helper).
-    fn env_def(agent: &'static AgentDef, var: &str) -> Option<&'static EnvAuthDef> {
-        agent.env_auth.iter().find(|e| e.env_var == var)
+    /// Build a `DetectedAgent` from a fake env lookup + home (test helper).
+    fn detect(
+        agent: &'static AgentDef,
+        env: impl Fn(&str) -> Option<String>,
+        home: Option<&Path>,
+        image_exists: bool,
+    ) -> Option<DetectedAgent> {
+        resolve_auth(agent, env, home).map(|auth| DetectedAgent {
+            agent,
+            auth,
+            image_exists,
+        })
+    }
+
+    /// An env lookup returning `val` for `name` and nothing else.
+    fn only(name: &'static str, val: &'static str) -> impl Fn(&str) -> Option<String> {
+        move |var| (var == name).then(|| val.to_string())
+    }
+
+    /// The env var of a resolved `EnvSecret` method, if any.
+    fn resolved_env_var(r: &ResolvedAuth) -> Option<&'static str> {
+        match r.method {
+            AuthMethod::EnvSecret { env_var, .. } => Some(env_var),
+            AuthMethod::StagedFiles { .. } => None,
+        }
     }
 
     #[test]
     fn detect_api_key_produces_correct_config() {
-        let api = env_def(&CLAUDE_CODE, "ANTHROPIC_API_KEY");
-        let detected =
-            probe_with_env(&CLAUDE_CODE, api, None, Some(true)).expect("should detect via API key");
-        assert!(matches!(detected.auth, ResolvedAuth::EnvVar(_)));
+        let detected = detect(
+            &CLAUDE_CODE,
+            only("ANTHROPIC_API_KEY", "sk-ant-test123"),
+            None,
+            true,
+        )
+        .expect("should detect via API key");
+        assert!(matches!(detected.auth.method, AuthMethod::EnvSecret { .. }));
 
         let auto = build_config(&detected);
         assert_eq!(auto.config.image.as_deref(), Some("claude-code"));
@@ -561,16 +576,17 @@ mod tests {
 
     #[test]
     fn detect_oauth_produces_correct_config() {
-        let tmp = std::env::temp_dir().join("redan-test-oauth-refactor");
-        let _ = std::fs::create_dir_all(&tmp);
-        let creds = tmp.join(".credentials.json");
+        let home = std::env::temp_dir().join("redan-test-oauth-refactor");
+        let claude = home.join(".claude");
+        let _ = std::fs::create_dir_all(&claude);
+        let creds = claude.join(".credentials.json");
         std::fs::write(&creds, "{}").unwrap();
 
-        let detected = probe_with_env(&CLAUDE_CODE, None, Some(&creds), Some(true))
-            .expect("should detect via OAuth");
+        let detected =
+            detect(&CLAUDE_CODE, |_| None, Some(&home), true).expect("should detect via OAuth");
         assert!(matches!(
-            detected.auth,
-            ResolvedAuth::StoredCredentials { .. }
+            detected.auth.method,
+            AuthMethod::StagedFiles { .. }
         ));
 
         let auto = build_config(&detected);
@@ -590,9 +606,6 @@ mod tests {
         assert_eq!(guest_dir, "/tmp/.claude");
         assert_eq!(filename, ".credentials.json");
 
-        // No config-dir mount (credentials are pre-staged)
-        assert!(!auto.config.mount.contains_key("claude-code-config"));
-
         assert!(
             auto.config
                 .network
@@ -601,61 +614,67 @@ mod tests {
         );
         assert!(auto.messages.iter().any(|m| m.contains("Staging")));
 
-        let _ = std::fs::remove_dir_all(&tmp);
+        let _ = std::fs::remove_dir_all(&home);
     }
 
     #[test]
-    fn api_key_takes_precedence_over_oauth() {
-        let tmp = std::env::temp_dir().join("redan-test-precedence-refactor");
-        let _ = std::fs::create_dir_all(&tmp);
-        let creds = tmp.join(".credentials.json");
-        std::fs::write(&creds, "{}").unwrap();
+    fn api_key_takes_precedence_over_staged_files() {
+        // Env var is earlier in the auth list than StagedFiles, so it wins
+        // even when the credentials file also exists.
+        let home = std::env::temp_dir().join("redan-test-precedence-refactor");
+        let claude = home.join(".claude");
+        let _ = std::fs::create_dir_all(&claude);
+        std::fs::write(claude.join(".credentials.json"), "{}").unwrap();
 
-        let api = env_def(&CLAUDE_CODE, "ANTHROPIC_API_KEY");
-        let detected =
-            probe_with_env(&CLAUDE_CODE, api, Some(&creds), Some(true)).expect("should detect");
-        assert!(matches!(detected.auth, ResolvedAuth::EnvVar(_)));
+        let detected = detect(
+            &CLAUDE_CODE,
+            only("ANTHROPIC_API_KEY", "sk"),
+            Some(&home),
+            true,
+        )
+        .expect("should detect");
+        assert!(matches!(detected.auth.method, AuthMethod::EnvSecret { .. }));
 
         let auto = build_config(&detected);
         assert!(auto.config.secrets.contains_key("ANTHROPIC_API_KEY"));
-        assert!(!auto.config.mount.contains_key("claude-code-config"));
+        assert!(auto.stage_files.is_empty());
 
-        let _ = std::fs::remove_dir_all(&tmp);
+        let _ = std::fs::remove_dir_all(&home);
     }
 
     #[test]
     fn no_auth_returns_none() {
-        assert!(probe_with_env(&CLAUDE_CODE, None, None, Some(true)).is_none());
+        assert!(detect(&CLAUDE_CODE, |_| None, None, true).is_none());
     }
 
     #[test]
-    fn match_env_auth_prefers_api_key_over_oauth_token() {
-        // Both set -> API key wins (matches Claude Code's own precedence).
-        let m = match_env_auth(&CLAUDE_CODE, |_| Some("value".into()));
-        assert_eq!(m.map(|e| e.env_var), Some("ANTHROPIC_API_KEY"));
+    fn resolve_prefers_api_key_over_oauth_token() {
+        // Both env vars set -> API key wins (it's first in the auth list,
+        // matching Claude Code's own precedence).
+        let r = resolve_auth(&CLAUDE_CODE, |_| Some("value".into()), None).unwrap();
+        assert_eq!(resolved_env_var(&r), Some("ANTHROPIC_API_KEY"));
     }
 
     #[test]
-    fn match_env_auth_falls_to_oauth_token_when_only_it_is_set() {
-        let m = match_env_auth(&CLAUDE_CODE, |var| {
-            (var == "CLAUDE_CODE_OAUTH_TOKEN").then(|| "tok".into())
-        });
-        assert_eq!(m.map(|e| e.env_var), Some("CLAUDE_CODE_OAUTH_TOKEN"));
+    fn resolve_falls_to_oauth_token_when_only_it_is_set() {
+        let r = resolve_auth(&CLAUDE_CODE, only("CLAUDE_CODE_OAUTH_TOKEN", "tok"), None).unwrap();
+        assert_eq!(resolved_env_var(&r), Some("CLAUDE_CODE_OAUTH_TOKEN"));
     }
 
     #[test]
-    fn match_env_auth_ignores_empty_values() {
-        let m = match_env_auth(&CLAUDE_CODE, |var| {
-            (var == "ANTHROPIC_API_KEY").then(|| "  ".into())
-        });
-        assert!(m.is_none());
+    fn resolve_ignores_empty_env_values() {
+        assert!(resolve_auth(&CLAUDE_CODE, only("ANTHROPIC_API_KEY", "  "), None).is_none());
     }
 
     #[test]
     fn oauth_token_injects_as_secret() {
-        let oauth = env_def(&CLAUDE_CODE, "CLAUDE_CODE_OAUTH_TOKEN");
-        let detected = probe_with_env(&CLAUDE_CODE, oauth, None, Some(true))
-            .expect("should detect via OAuth token");
+        let detected = detect(
+            &CLAUDE_CODE,
+            only("CLAUDE_CODE_OAUTH_TOKEN", "tok"),
+            None,
+            true,
+        )
+        .unwrap();
         let auto = build_config(&detected);
         let secret = auto.config.secrets.get("CLAUDE_CODE_OAUTH_TOKEN").unwrap();
         assert_eq!(secret.value, "env://CLAUDE_CODE_OAUTH_TOKEN");
@@ -665,35 +684,32 @@ mod tests {
     }
 
     #[test]
-    fn empty_api_key_falls_through_to_oauth() {
-        let tmp = std::env::temp_dir().join("redan-test-empty-key");
-        let _ = std::fs::create_dir_all(&tmp);
-        let creds = tmp.join(".credentials.json");
-        std::fs::write(&creds, "{}").unwrap();
+    fn empty_api_key_falls_through_to_staged_files() {
+        let home = std::env::temp_dir().join("redan-test-empty-key");
+        let claude = home.join(".claude");
+        let _ = std::fs::create_dir_all(&claude);
+        std::fs::write(claude.join(".credentials.json"), "{}").unwrap();
 
         // Empty env vars don't match; fall back to staged credentials.
-        let env_match = match_env_auth(&CLAUDE_CODE, |_| Some(String::new()));
-        assert!(env_match.is_none());
-        let detected = probe_with_env(&CLAUDE_CODE, env_match, Some(&creds), Some(true))
-            .expect("should fall through to OAuth");
+        let detected = detect(&CLAUDE_CODE, |_| Some(String::new()), Some(&home), true)
+            .expect("should fall through to staged files");
         assert!(matches!(
-            detected.auth,
-            ResolvedAuth::StoredCredentials { .. }
+            detected.auth.method,
+            AuthMethod::StagedFiles { .. }
         ));
 
-        let _ = std::fs::remove_dir_all(&tmp);
+        let _ = std::fs::remove_dir_all(&home);
     }
 
     #[test]
-    fn empty_api_key_no_oauth_returns_none() {
-        let env_match = match_env_auth(&CLAUDE_CODE, |_| Some("  ".into()));
-        assert!(probe_with_env(&CLAUDE_CODE, env_match, None, Some(true)).is_none());
+    fn empty_api_key_no_files_returns_none() {
+        assert!(detect(&CLAUDE_CODE, |_| Some("  ".into()), None, true).is_none());
     }
 
     #[test]
     fn needs_image_build_when_image_missing() {
-        let api = env_def(&CLAUDE_CODE, "ANTHROPIC_API_KEY");
-        let detected = probe_with_env(&CLAUDE_CODE, api, None, Some(false)).expect("should detect");
+        let detected =
+            detect(&CLAUDE_CODE, only("ANTHROPIC_API_KEY", "sk"), None, false).expect("detect");
         let auto = build_config(&detected);
         assert!(auto.needs_image_build);
         assert!(auto.messages.iter().any(|m| m.contains("will build")));
@@ -701,10 +717,9 @@ mod tests {
 
     #[test]
     fn pi_api_key_produces_correct_config() {
-        let api = env_def(&PI, "ANTHROPIC_API_KEY");
-        let detected =
-            probe_with_env(&PI, api, None, Some(true)).expect("should detect Pi via API key");
-        assert!(matches!(detected.auth, ResolvedAuth::EnvVar(_)));
+        let detected = detect(&PI, only("ANTHROPIC_API_KEY", "sk-ant-test123"), None, true)
+            .expect("should detect Pi via API key");
+        assert!(matches!(detected.auth.method, AuthMethod::EnvSecret { .. }));
 
         let auto = build_config(&detected);
         assert_eq!(auto.config.image.as_deref(), Some("pi"));
@@ -721,17 +736,16 @@ mod tests {
     }
 
     #[test]
-    fn pi_stored_credentials_stages_multiple_files() {
-        let tmp = std::env::temp_dir().join("redan-test-pi-creds");
-        let _ = std::fs::create_dir_all(&tmp);
-        let auth_file = tmp.join("auth.json");
-        let settings = tmp.join("settings.json");
-        std::fs::write(&auth_file, "{}").unwrap();
-        std::fs::write(&settings, "{}").unwrap();
+    fn pi_staged_files_stages_only_present_files() {
+        let home = std::env::temp_dir().join("redan-test-pi-creds");
+        let agent_dir = home.join(".pi/agent");
+        let _ = std::fs::create_dir_all(&agent_dir);
+        std::fs::write(agent_dir.join("auth.json"), "{}").unwrap();
+        std::fs::write(agent_dir.join("settings.json"), "{}").unwrap();
         // models.json intentionally absent: only existing files get staged
 
-        let detected = probe_with_env(&PI, None, Some(&auth_file), Some(true))
-            .expect("should detect Pi via stored credentials");
+        let detected = detect(&PI, |_| None, Some(&home), true)
+            .expect("should detect Pi via staged credentials");
         let auto = build_config(&detected);
 
         assert_eq!(auto.stage_files.len(), 2);
@@ -748,7 +762,7 @@ mod tests {
             assert_eq!(dir, "/home/dev/.pi/agent");
         }
 
-        let _ = std::fs::remove_dir_all(&tmp);
+        let _ = std::fs::remove_dir_all(&home);
     }
 
     #[test]

--- a/src/auto_detect.rs
+++ b/src/auto_detect.rs
@@ -23,6 +23,7 @@ use crate::image;
 static AGENTS: &[&AgentDef] = &[&CLAUDE_CODE, &PI];
 
 static CLAUDE_CODE: AgentDef = AgentDef {
+    slug: "claude",
     name: "Claude Code",
     image: "claude-code",
     command: "claude --dangerously-skip-permissions",
@@ -53,6 +54,7 @@ static CLAUDE_CODE: AgentDef = AgentDef {
 };
 
 static PI: AgentDef = AgentDef {
+    slug: "pi",
     name: "Pi",
     image: "pi",
     command: "pi",
@@ -82,6 +84,8 @@ static PI: AgentDef = AgentDef {
 
 /// A coding agent that redan can auto-detect and sandbox.
 pub struct AgentDef {
+    /// Short, stable identifier for `redan run <slug>` (e.g. "claude").
+    pub slug: &'static str,
     pub name: &'static str,
     pub image: &'static str,
     pub command: &'static str,
@@ -173,22 +177,52 @@ pub fn detect() -> Option<AutoDetected> {
 /// Detect all agents whose auth requirements are satisfied.
 /// Returns them in registry order (highest priority first).
 pub fn detect_all() -> Vec<DetectedAgent> {
-    let home = std::env::var("HOME").ok();
     AGENTS
         .iter()
-        .filter_map(|agent| {
-            let api_key_val = agent
-                .api_key
-                .as_ref()
-                .and_then(|a| std::env::var(a.env_var).ok());
-            let oauth_creds = home.as_ref().and_then(|h| {
-                let sc = agent.stored_credentials.as_ref()?;
-                let path = Path::new(h).join(sc.home_dir).join(sc.credentials_file);
-                path.exists().then_some(path)
-            });
-            probe_with_env(agent, api_key_val.as_deref(), oauth_creds.as_deref(), None)
-        })
+        .filter_map(|&agent| detect_one(agent))
         .collect()
+}
+
+/// Look up an agent by its `redan run` slug (e.g. "claude", "pi").
+pub fn agent_by_slug(slug: &str) -> Option<&'static AgentDef> {
+    AGENTS.iter().find(|a| a.slug == slug).copied()
+}
+
+/// All known agent slugs, in registry order.
+pub fn agent_slugs() -> Vec<&'static str> {
+    AGENTS.iter().map(|a| a.slug).collect()
+}
+
+/// Why [`resolve_by_slug`] could not produce a Config.
+pub enum ResolveError {
+    /// No agent registered under that slug.
+    Unknown,
+    /// The agent exists but its auth requirements aren't met.
+    NoAuth(&'static AgentDef),
+}
+
+/// Resolve a single named agent, probing its auth against the environment.
+/// This is the `redan run <slug>` entry point: unlike [`detect`], the agent
+/// is chosen explicitly rather than by registry priority.
+pub fn resolve_by_slug(slug: &str) -> Result<AutoDetected, ResolveError> {
+    let agent = agent_by_slug(slug).ok_or(ResolveError::Unknown)?;
+    let detected = detect_one(agent).ok_or(ResolveError::NoAuth(agent))?;
+    Ok(build_config(&detected))
+}
+
+/// Probe a single agent's auth requirements against the current environment.
+fn detect_one(agent: &'static AgentDef) -> Option<DetectedAgent> {
+    let home = std::env::var("HOME").ok();
+    let api_key_val = agent
+        .api_key
+        .as_ref()
+        .and_then(|a| std::env::var(a.env_var).ok());
+    let oauth_creds = home.as_ref().and_then(|h| {
+        let sc = agent.stored_credentials.as_ref()?;
+        let path = Path::new(h).join(sc.home_dir).join(sc.credentials_file);
+        path.exists().then_some(path)
+    });
+    probe_with_env(agent, api_key_val.as_deref(), oauth_creds.as_deref(), None)
 }
 
 // ---------------------------------------------------------------------------
@@ -645,6 +679,32 @@ mod tests {
         }
 
         let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn agent_by_slug_resolves_known() {
+        assert_eq!(agent_by_slug("claude").map(|a| a.name), Some("Claude Code"));
+        assert_eq!(agent_by_slug("pi").map(|a| a.name), Some("Pi"));
+    }
+
+    #[test]
+    fn agent_by_slug_unknown_is_none() {
+        assert!(agent_by_slug("nope").is_none());
+    }
+
+    #[test]
+    fn agent_slugs_lists_registry() {
+        let slugs = agent_slugs();
+        assert!(slugs.contains(&"claude"));
+        assert!(slugs.contains(&"pi"));
+    }
+
+    #[test]
+    fn resolve_unknown_slug_errors() {
+        assert!(matches!(
+            resolve_by_slug("nope"),
+            Err(ResolveError::Unknown)
+        ));
     }
 
     fn empty_flags() -> ExecFlags<'static> {

--- a/src/auto_detect.rs
+++ b/src/auto_detect.rs
@@ -37,7 +37,10 @@ static CLAUDE_CODE: AgentDef = AgentDef {
     interactive: true,
     timeout_secs: 3600,
     run_as: Some("dev"),
-    guest_env: &[("HOME", "/home/dev")],
+    guest_env: &[
+        ("HOME", "/home/dev"),
+        ("NODE_PATH", "/usr/lib/node_modules"),
+    ],
     // ANTHROPIC_API_KEY first to match Claude Code's own auth precedence
     // (API key over OAuth token). CLAUDE_CODE_OAUTH_TOKEN is the reliable
     // subscription path for sandboxes: a 1-year token from `claude
@@ -73,7 +76,10 @@ static PI: AgentDef = AgentDef {
     interactive: true,
     timeout_secs: 3600,
     run_as: Some("dev"),
-    guest_env: &[("HOME", "/home/dev")],
+    guest_env: &[
+        ("HOME", "/home/dev"),
+        ("NODE_PATH", "/usr/lib/node_modules"),
+    ],
     auth: &[
         AuthMethod::EnvSecret {
             env_var: "ANTHROPIC_API_KEY",

--- a/src/cmd/exec.rs
+++ b/src/cmd/exec.rs
@@ -156,11 +156,22 @@ pub(crate) fn run(cfg: &ExecConfig<'_>) -> i32 {
     // Parse mounts
     let mut virtiofs_mounts: Vec<(String, String, bool)> = Vec::new();
     let mut mount_commands: Vec<String> = Vec::new();
+    // The mount of the host's current directory becomes the guest working
+    // directory, so the agent starts in the project (sees its git repo,
+    // relative paths) instead of in `/`.
+    let cwd = std::env::current_dir().and_then(std::fs::canonicalize).ok();
+    let mut workdir: Option<String> = None;
     for (i, spec) in cfg.mount_specs.iter().enumerate() {
         let (host_path, guest_path, read_only) = parse_mount(spec);
         if !Path::new(&host_path).exists() {
             eprintln!("mount source does not exist: {host_path}");
             std::process::exit(1);
+        }
+        if workdir.is_none()
+            && let Some(cwd) = &cwd
+            && std::fs::canonicalize(&host_path).is_ok_and(|p| &p == cwd)
+        {
+            workdir = Some(guest_path.clone());
         }
         let tag = format!("fs{i}");
         let ro_label = if read_only { " (ro)" } else { "" };
@@ -187,7 +198,10 @@ pub(crate) fn run(cfg: &ExecConfig<'_>) -> i32 {
     let ca_update = vm::ca_update_commands();
     let mount_setup = mount_commands.join("; ");
     let ensure_user = cfg.run_as.map(ensure_user_command);
-    let user_command = wrap_run_as(cfg.command, cfg.run_as);
+    // `cd` runs in the boot shell after the virtio-fs mount, so the cwd
+    // resolves to the mounted directory (not the empty pre-mount inode);
+    // `runuser` then inherits it. Keeps the no-extra-`sh -c` TTY passthrough.
+    let user_command = with_workdir(wrap_run_as(cfg.command, cfg.run_as), workdir.as_deref());
 
     let mut parts = vec![net_setup, ca_update.to_string()];
     if !mount_setup.is_empty() {
@@ -556,6 +570,15 @@ fn wrap_run_as(command: &str, run_as: Option<&str>) -> String {
     format!("runuser -u {user} -- {command}")
 }
 
+/// Prepend `cd <workdir> &&` so the agent starts in the mounted project
+/// directory. No-op when there's no working directory or it's root.
+fn with_workdir(command: String, workdir: Option<&str>) -> String {
+    match workdir {
+        Some(dir) if dir != "/" => format!("cd {dir} && {command}"),
+        _ => command,
+    }
+}
+
 fn write_guest_policy(rootfs: &Path, allowed_hosts: Option<&Vec<String>>) {
     let dir = rootfs.join("etc/redan");
     if std::fs::create_dir_all(&dir).is_err() {
@@ -683,6 +706,24 @@ mod tests {
     fn wrap_run_as_preserves_command_verbatim() {
         let result = wrap_run_as("echo 'hello world'", Some("dev"));
         assert_eq!(result, "runuser -u dev -- echo 'hello world'");
+    }
+
+    #[test]
+    fn with_workdir_prepends_cd() {
+        assert_eq!(
+            with_workdir("runuser -u dev -- claude".into(), Some("/workspace")),
+            "cd /workspace && runuser -u dev -- claude"
+        );
+    }
+
+    #[test]
+    fn with_workdir_root_is_noop() {
+        assert_eq!(with_workdir("claude".into(), Some("/")), "claude");
+    }
+
+    #[test]
+    fn with_workdir_none_is_noop() {
+        assert_eq!(with_workdir("claude".into(), None), "claude");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -175,6 +175,65 @@ enum Cli {
         name: Option<String>,
     },
 
+    /// Launch a coding agent in a sandbox (claude, pi). Zero-config.
+    ///
+    /// `redan run` picks the agent's image, command, auth, and network
+    /// policy for you. Omit the agent name to auto-detect. For full manual
+    /// control over image and command, use `redan exec` instead.
+    Run {
+        /// Agent to launch (e.g. `claude`, `pi`). Omit to auto-detect.
+        agent: Option<String>,
+
+        /// Allow outbound HTTPS to a host (in addition to the agent's own).
+        /// Use '*' to allow all outbound connections.
+        #[arg(long = "allow-host", value_name = "HOST")]
+        allow_hosts: Vec<String>,
+
+        /// Launch headless Chrome on the host with CDP access from the guest.
+        #[arg(long)]
+        browser: bool,
+
+        /// Mount a host directory into the guest via virtio-fs.
+        #[arg(long = "mount", short = 'm', value_name = "HOST:GUEST")]
+        mounts: Vec<String>,
+
+        /// Forward a guest TCP port to host localhost (PORT or GUEST:HOST).
+        #[arg(long = "forward", value_name = "SPEC")]
+        forwards: Vec<String>,
+
+        /// Inject a secret: `ENV_VAR=real_value:host1,host2`
+        #[arg(long = "secret", short = 's', value_name = "SPEC")]
+        secrets: Vec<String>,
+
+        /// Read secret specs from a file (one per line).
+        #[arg(long, value_name = "PATH")]
+        secret_file: Option<String>,
+
+        /// Write structured audit events to a JSON-lines file.
+        #[arg(long, value_name = "PATH")]
+        audit_log: Option<String>,
+
+        /// Proxy timeout in seconds (0 = wait for VM exit).
+        #[arg(long)]
+        timeout: Option<u64>,
+
+        /// Discover mode: allow all connections, print observed hosts at exit.
+        #[arg(long)]
+        discover: bool,
+
+        /// Run session in the background. Use `redan attach` to reconnect.
+        #[arg(long, short = 'd')]
+        detach: bool,
+
+        /// Name this session for easy reference.
+        #[arg(long)]
+        name: Option<String>,
+
+        /// Extra arguments appended to the agent command (after `--`).
+        #[arg(last = true)]
+        extra: Vec<String>,
+    },
+
     /// Attach to a running session
     Attach {
         /// Session ID or name (default: most recent running session)
@@ -328,6 +387,37 @@ fn main() {
                 name,
                 run_as: None,
                 browser,
+            });
+        }
+        Cli::Run {
+            agent,
+            allow_hosts,
+            browser,
+            mounts,
+            forwards,
+            secrets,
+            secret_file,
+            audit_log,
+            timeout,
+            discover,
+            detach,
+            name,
+            extra,
+        } => {
+            run_command(RunArgs {
+                agent,
+                allow_hosts,
+                browser,
+                mounts,
+                forwards,
+                secrets,
+                secret_file,
+                audit_log,
+                timeout,
+                discover,
+                detach,
+                name,
+                extra,
             });
         }
         Cli::Attach { session } => attach_session(session.as_deref()),
@@ -536,17 +626,7 @@ fn exec_command(args: ExecArgs) {
     } else if !explicit {
         // No config, no explicit flags: try auto-detect
         if let Some(auto) = redan::auto_detect::detect() {
-            if auto.needs_image_build {
-                let image_name = auto.config.image.as_deref().unwrap_or("unknown");
-                eprintln!("Building {image_name} image (this may take a minute)...");
-                match build_bundled_image(image_name) {
-                    Ok(_) => eprintln!("Image {image_name} built successfully."),
-                    Err(e) => {
-                        eprintln!("error: failed to build {image_name} image: {e}");
-                        std::process::exit(1);
-                    }
-                }
-            }
+            build_image_if_needed(&auto);
             for msg in &auto.messages {
                 eprintln!("  {msg}");
             }
@@ -571,7 +651,36 @@ fn exec_command(args: ExecArgs) {
     } else {
         (config::Config::default(), None, Vec::new())
     };
-    let run_as = args.run_as.or(run_as);
+
+    launch(&cfg, run_as, &stage_files, args);
+}
+
+/// Build an agent's image if auto-detect flagged it missing.
+fn build_image_if_needed(auto: &redan::auto_detect::AutoDetected) {
+    if !auto.needs_image_build {
+        return;
+    }
+    let image_name = auto.config.image.as_deref().unwrap_or("unknown");
+    eprintln!("Building {image_name} image (this may take a minute)...");
+    match build_bundled_image(image_name) {
+        Ok(_) => eprintln!("Image {image_name} built successfully."),
+        Err(e) => {
+            eprintln!("error: failed to build {image_name} image: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+/// Resolve final config from a base Config plus CLI overrides, then boot.
+/// Shared by `redan exec` (base from config/flags/auto-detect) and
+/// `redan run` (base from a named agent profile).
+fn launch(
+    cfg: &config::Config,
+    detected_run_as: Option<String>,
+    stage_files: &[(std::path::PathBuf, String, String)],
+    args: ExecArgs,
+) {
+    let run_as = args.run_as.or(detected_run_as);
 
     let mut all_secrets =
         cmd::exec::collect_secret_specs(&args.secrets, args.secret_file.as_deref());
@@ -640,7 +749,7 @@ fn exec_command(args: ExecArgs) {
     // Stage credentials into the rootfs before boot (like CA cert install).
     // Runs on the host, no mount or runtime copy needed.
     let chown_dir: Option<String> = stage_files.first().map(|(_, d, _)| d.clone());
-    for (host_path, guest_dir, filename) in &stage_files {
+    for (host_path, guest_dir, filename) in stage_files {
         let target_dir = std::path::Path::new(&rootfs_path)
             .join(guest_dir.strip_prefix('/').unwrap_or(guest_dir));
         if let Err(e) = std::fs::create_dir_all(&target_dir) {
@@ -714,6 +823,133 @@ fn exec_command(args: ExecArgs) {
         });
         std::process::exit(guest_code);
     }
+}
+
+struct RunArgs {
+    agent: Option<String>,
+    allow_hosts: Vec<String>,
+    browser: bool,
+    mounts: Vec<String>,
+    forwards: Vec<String>,
+    secrets: Vec<String>,
+    secret_file: Option<String>,
+    audit_log: Option<String>,
+    timeout: Option<u64>,
+    discover: bool,
+    detach: bool,
+    name: Option<String>,
+    extra: Vec<String>,
+}
+
+/// Resolve which agent `redan run` should launch. Exits with a helpful
+/// message if the slug is unknown, the agent lacks credentials, or no
+/// agent could be auto-detected.
+fn resolve_run_target(agent: Option<&str>) -> redan::auto_detect::AutoDetected {
+    use redan::auto_detect::{self, ResolveError};
+
+    let Some(slug) = agent else {
+        let Some(auto) = auto_detect::detect() else {
+            eprintln!(
+                "no agent detected. Known agents: {}",
+                auto_detect::agent_slugs().join(", ")
+            );
+            eprintln!();
+            eprintln!("  Authenticate one, then `redan run <agent>`:");
+            eprintln!("    export ANTHROPIC_API_KEY=sk-ant-...   (API key)");
+            eprintln!("    claude login                          (Claude Pro/Max/Team)");
+            std::process::exit(1);
+        };
+        return auto;
+    };
+
+    match auto_detect::resolve_by_slug(slug) {
+        Ok(auto) => auto,
+        Err(ResolveError::Unknown) => {
+            eprintln!(
+                "unknown agent '{slug}'. Available: {}",
+                auto_detect::agent_slugs().join(", ")
+            );
+            eprintln!("  Or run `redan run` with no agent to auto-detect.");
+            std::process::exit(1);
+        }
+        Err(ResolveError::NoAuth(found)) => {
+            eprintln!(
+                "{} found, but no credentials in this environment.",
+                found.name
+            );
+            print_agent_auth_hint(found);
+            std::process::exit(1);
+        }
+    }
+}
+
+/// `redan run <agent>`: launch a named agent profile (or auto-detect when
+/// no agent is given), then funnel into the shared `launch` path.
+fn run_command(args: RunArgs) {
+    let auto = resolve_run_target(args.agent.as_deref());
+
+    build_image_if_needed(&auto);
+    for msg in &auto.messages {
+        eprintln!("  {msg}");
+    }
+
+    let run_as = auto.run_as.map(Into::into);
+
+    // Append any post-`--` args to the agent command (e.g. an initial prompt).
+    let command = if args.extra.is_empty() {
+        None
+    } else {
+        let base = auto.config.command.clone().unwrap_or_default();
+        let extra = args
+            .extra
+            .iter()
+            .map(|a| shell_quote(a))
+            .collect::<Vec<_>>()
+            .join(" ");
+        Some(format!("{base} {extra}").trim().to_string())
+    };
+
+    launch(
+        &auto.config,
+        run_as,
+        &auto.stage_files,
+        ExecArgs {
+            image_name: None, // the agent's Config carries the image
+            rootfs: None,
+            command,
+            interactive: false, // the agent's Config carries interactive
+            timeout: args.timeout,
+            secrets: args.secrets,
+            secret_file: args.secret_file,
+            allow_hosts: args.allow_hosts,
+            mounts: args.mounts,
+            audit_log: args.audit_log,
+            forwards: args.forwards,
+            discover: args.discover,
+            detach: args.detach,
+            name: args.name,
+            run_as: None, // the agent's run_as flows via detected_run_as
+            browser: args.browser,
+        },
+    );
+}
+
+/// Print how to authenticate an agent whose creds weren't found.
+fn print_agent_auth_hint(agent: &redan::auto_detect::AgentDef) {
+    if let Some(api) = agent.api_key.as_ref() {
+        eprintln!("  export {}=...   (API key)", api.env_var);
+    }
+    if let Some(sc) = agent.stored_credentials.as_ref() {
+        eprintln!(
+            "  or authenticate so ~/{}/{} exists",
+            sc.home_dir, sc.credentials_file
+        );
+    }
+}
+
+/// Single-quote a shell argument so it survives `/bin/sh -c`.
+fn shell_quote(arg: &str) -> String {
+    format!("'{}'", arg.replace('\'', "'\\''"))
 }
 
 /// Serializable exec config for passing to the daemon process.
@@ -1245,4 +1481,28 @@ fn build_bundled_image(name: &str) -> std::io::Result<std::path::PathBuf> {
     let result = image::import_dockerfile(name, df_path.to_str().unwrap_or(""));
     let _ = std::fs::remove_dir_all(&tmp);
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::shell_quote;
+
+    #[test]
+    fn shell_quote_wraps_plain_arg() {
+        assert_eq!(shell_quote("fix the bug"), "'fix the bug'");
+    }
+
+    #[test]
+    fn shell_quote_escapes_embedded_single_quote() {
+        // don't -> 'don'\''t' (close, escaped quote, reopen)
+        assert_eq!(shell_quote("don't"), "'don'\\''t'");
+    }
+
+    #[test]
+    fn shell_quote_neutralizes_shell_metacharacters() {
+        // Passthrough args must not break out of the agent command.
+        assert_eq!(shell_quote("; rm -rf /"), "'; rm -rf /'");
+        assert_eq!(shell_quote("$(whoami)"), "'$(whoami)'");
+        assert_eq!(shell_quote("a && b"), "'a && b'");
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -936,18 +936,24 @@ fn run_command(args: RunArgs) {
 
 /// Print how to authenticate an agent whose creds weren't found.
 fn print_agent_auth_hint(agent: &redan::auto_detect::AgentDef) {
-    for e in agent.env_auth {
-        if e.env_var == "CLAUDE_CODE_OAUTH_TOKEN" {
-            eprintln!("  run `claude setup-token`, then export CLAUDE_CODE_OAUTH_TOKEN (1-year)");
-        } else {
-            eprintln!("  export {}=...", e.env_var);
+    use redan::auto_detect::AuthMethod;
+    for method in agent.auth {
+        match method {
+            AuthMethod::EnvSecret {
+                env_var: "CLAUDE_CODE_OAUTH_TOKEN",
+                ..
+            } => {
+                eprintln!(
+                    "  run `claude setup-token`, then export CLAUDE_CODE_OAUTH_TOKEN (1-year)"
+                );
+            }
+            AuthMethod::EnvSecret { env_var, .. } => eprintln!("  export {env_var}=..."),
+            AuthMethod::StagedFiles { dir, probe, .. } => {
+                eprintln!(
+                    "  or sign in so ~/{dir}/{probe} exists (less reliable; it can go stale)"
+                );
+            }
         }
-    }
-    if let Some(sc) = agent.stored_credentials.as_ref() {
-        eprintln!(
-            "  or sign in so ~/{}/{} exists (less reliable; it can go stale)",
-            sc.home_dir, sc.credentials_file
-        );
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -936,12 +936,16 @@ fn run_command(args: RunArgs) {
 
 /// Print how to authenticate an agent whose creds weren't found.
 fn print_agent_auth_hint(agent: &redan::auto_detect::AgentDef) {
-    if let Some(api) = agent.api_key.as_ref() {
-        eprintln!("  export {}=...   (API key)", api.env_var);
+    for e in agent.env_auth {
+        if e.env_var == "CLAUDE_CODE_OAUTH_TOKEN" {
+            eprintln!("  run `claude setup-token`, then export CLAUDE_CODE_OAUTH_TOKEN (1-year)");
+        } else {
+            eprintln!("  export {}=...", e.env_var);
+        }
     }
     if let Some(sc) = agent.stored_credentials.as_ref() {
         eprintln!(
-            "  or authenticate so ~/{}/{} exists",
+            "  or sign in so ~/{}/{} exists (less reliable; it can go stale)",
             sc.home_dir, sc.credentials_file
         );
     }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -315,7 +315,14 @@ pub fn run(cfg: ProxyConfig<'_>) -> Vec<String> {
             log::info!("proxy timeout ({timeout:?}). Use --timeout 0 for no limit.");
             break;
         }
-        if device.peer_closed && connections.is_empty() {
+        // The guest VM is gone once its virtio-net socket closes. It dies
+        // abruptly (libkrun _exit on guest shutdown), so its open TCP
+        // connections never send FIN and their smoltcp sockets would sit
+        // in Established forever -- waiting for `connections` to drain
+        // would hang until the proxy timeout. There's no live peer left to
+        // serve, so break now; dropping the connections on return signals
+        // the relay threads to stop.
+        if device.peer_closed {
             log::info!("guest exited (socket closed)");
             break;
         }


### PR DESCRIPTION
`redan run claude` / `redan run pi` launch a known agent with its image,
command, auth, network policy, and privilege drop chosen automatically.
Omit the agent to auto-detect. `redan exec` stays the low-level command
for explicit image/command control, so the two verbs split cleanly:
`run` is curated, `exec` is the universal engine.

The registry side (`auto_detect`) gains a `slug` per agent plus
`agent_by_slug`/`agent_slugs`/`resolve_by_slug`; the last probes a single
named agent's auth and returns Unknown / NoAuth / Ready. `detect_one` is
factored out of `detect_all` so single-agent and all-agent detection
share one path.

On the CLI side, the new `Run` variant feeds `run_command`, which funnels
into a `launch()` helper extracted from `exec_command`'s back half. Both
commands now share credential staging, image resolution, dispatch, and
exit-code propagation, so nothing is duplicated between them. Trailing
`redan run claude -- "prompt"` appends to the agent command (shell-quoted
to block injection); unknown slugs and missing creds print the fix.

The way out of "only claude and pi" is more profiles, not arbitrary
commands: `run` stays opinionated, and user-defined profiles are the
planned growth path.

Verified locally: `run pi -- --version` stages all three Pi creds, runs
as dev, returns pi 0.78.1; `run claude` stages the OAuth credential; bare
`run` auto-detects; `run bogus` errors with the agent list. `shell_quote`
is unit-tested against injection. `mise run check` is green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `redan run` to launch agents with zero‑config defaults, automatic image build, and credential handling.

* **Documentation**
  * Updated getting‑started guide and examples; changed examples to use `-c` for passing agent commands and new discovery invocation.

* **Improvements**
  * Agent selection via stable short identifiers and clearer auth hints; run now starts interactive sessions in the mounted project directory when applicable.

* **Bug Fixes**
  * Quicker VM/network teardown when the guest networking peer closes.

* **Images**
  * Agent images extended to include browser automation tooling for CDP/WebSocket tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->