### PR TITLE
fix(config): keep agent config out of the mounted workspace

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -41,7 +41,9 @@ run = "cargo build --release"
 
 [tasks.install]
 description = "Build and install to ~/.cargo/bin"
-run = "cargo install --path ."
+# --locked: cargo install otherwise ignores Cargo.lock and re-resolves, which
+# can pull a newer `time` that conflicts with `rcgen` (trait impl clash, E0119).
+run = "cargo install --path . --locked"
 
 [tasks.bench]
 description = "Boot-to-proxy benchmark (requires KVM + image)"

--- a/src/auto_detect.rs
+++ b/src/auto_detect.rs
@@ -49,20 +49,20 @@ static CLAUDE_CODE: AgentDef = AgentDef {
         AuthMethod::EnvSecret {
             env_var: "ANTHROPIC_API_KEY",
             hosts: &["api.anthropic.com"],
-            guest_env: &[("CLAUDE_CONFIG_DIR", "/workspace/.claude")],
+            guest_env: &[("CLAUDE_CONFIG_DIR", "/home/dev/.claude")],
         },
         AuthMethod::EnvSecret {
             env_var: "CLAUDE_CODE_OAUTH_TOKEN",
             hosts: &["api.anthropic.com"],
-            guest_env: &[("CLAUDE_CONFIG_DIR", "/workspace/.claude")],
+            guest_env: &[("CLAUDE_CONFIG_DIR", "/home/dev/.claude")],
         },
         AuthMethod::StagedFiles {
             dir: ".claude",
             probe: ".credentials.json",
             files: &[".credentials.json"],
-            guest_dir: "/tmp/.claude",
+            guest_dir: "/home/dev/.claude",
             hosts: &["auth.anthropic.com", "console.anthropic.com"],
-            guest_env: &[("CLAUDE_CONFIG_DIR", "/tmp/.claude")],
+            guest_env: &[("CLAUDE_CONFIG_DIR", "/home/dev/.claude")],
         },
     ],
 };
@@ -569,7 +569,7 @@ mod tests {
 
         assert_eq!(
             auto.config.env.get("CLAUDE_CONFIG_DIR").map(String::as_str),
-            Some("/workspace/.claude")
+            Some("/home/dev/.claude")
         );
 
         assert!(auto.config.mount.contains_key("workspace"));
@@ -599,17 +599,17 @@ mod tests {
         assert_eq!(auto.config.image.as_deref(), Some("claude-code"));
         assert!(auto.config.secrets.is_empty());
 
-        // CLAUDE_CONFIG_DIR points to guest-only tmp dir
+        // CLAUDE_CONFIG_DIR is the guest-only config dir (not the workspace)
         assert_eq!(
             auto.config.env.get("CLAUDE_CONFIG_DIR").map(String::as_str),
-            Some("/tmp/.claude")
+            Some("/home/dev/.claude")
         );
 
         // Credentials staged into rootfs before boot (no mount, no runtime copy)
         assert_eq!(auto.stage_files.len(), 1);
         let (host_path, guest_dir, filename) = &auto.stage_files[0];
         assert_eq!(host_path, &creds);
-        assert_eq!(guest_dir, "/tmp/.claude");
+        assert_eq!(guest_dir, "/home/dev/.claude");
         assert_eq!(filename, ".credentials.json");
 
         assert!(

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -52,9 +52,10 @@ pub(crate) fn run(claude: bool) {
         cfg.command = Some("claude --dangerously-skip-permissions".into());
         cfg.interactive = Some(true);
 
-        // Point Claude Code's config to workspace so sessions persist
+        // Claude's config in a guest-only dir, not the mounted workspace,
+        // so its credentials and history don't land in the project.
         cfg.env
-            .insert("CLAUDE_CONFIG_DIR".into(), "/workspace/.claude".into());
+            .insert("CLAUDE_CONFIG_DIR".into(), "/home/dev/.claude".into());
 
         // Claude Code API hosts
         let claude_hosts = [

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -121,7 +121,7 @@ mod tests {
             },
         );
         cfg.env
-            .insert("CLAUDE_CONFIG_DIR".into(), "/workspace/.claude".into());
+            .insert("CLAUDE_CONFIG_DIR".into(), "/home/dev/.claude".into());
 
         let out = redan_toml(&cfg, true);
         assert!(out.contains("--dangerously-skip-permissions"));


### PR DESCRIPTION
`CLAUDE_CONFIG_DIR` was set to `/workspace/.claude`, which is the mounted
host repo. So every `redan run claude` wrote the agent's config, session
history, and a real `.credentials.json` OAuth token straight into whatever
project you ran it in. In repos that don't gitignore `.claude`, that's an
uncommitted token sitting in the working tree.

Points it at `/home/dev/.claude` instead: guest-only, not part of any
mount, so config stays in the ephemeral VM and can't leak back to the
host. Changed in the three places the path appeared: the `StagedFiles`
auth path and `CLAUDE_CODE` guest_env in `auto_detect.rs`, the
`redan init --claude` output in `cmd/init.rs`, and a test fixture in
`templates.rs`.

Drive-by in the second commit: `mise run install` was failing because
`cargo install` ignores `Cargo.lock` and re-resolved to a newer `time`
that conflicts with `rcgen` (E0119 trait-impl clash). Added `--locked`
so it builds against the same lock as `mise run check`.

Note: this stops new leaks. Tokens already written into repos by earlier
runs need manual cleanup, they're never committed but they're real tokens
in working trees.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Installation process now uses locked dependencies to ensure reproducible and consistent builds across different environments and systems
  * Configuration directories have been standardized, with Claude tool configuration now consolidated to a dedicated location
  
* **Tests**
  * Test cases updated to verify correct behavior with new configuration paths

<!-- end of auto-generated comment: release notes by coderabbit.ai -->