### PR TITLE
fix(security): filter scrub() on per-secret host allowlist

### DIFF
--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -1136,6 +1136,7 @@ fn tls_connection_thread(
                         write_scrubbed_chunk(
                             &mut tls,
                             &upstream_buf[..n],
+                            &sni,
                             secrets,
                             max_secret_len,
                             &mut scrub_overlap,
@@ -1171,7 +1172,8 @@ fn tls_connection_thread(
                                 );
                             }
 
-                            let (scrubbed, scrub_count) = crate::secret::scrub(&headers, secrets);
+                            let (scrubbed, scrub_count) =
+                                crate::secret::scrub(&headers, &sni, secrets);
                             if scrub_count > 0 {
                                 log::info!("HEADERS SCRUBBED: {scrub_count} value(s)");
                                 audit(
@@ -1192,6 +1194,7 @@ fn tls_connection_thread(
                                 write_scrubbed_chunk(
                                     &mut tls,
                                     &body_remainder,
+                                    &sni,
                                     secrets,
                                     max_secret_len,
                                     &mut scrub_overlap,
@@ -1215,6 +1218,7 @@ fn tls_connection_thread(
                             write_scrubbed_chunk(
                                 &mut tls,
                                 &upstream_buf[..n],
+                                &sni,
                                 secrets,
                                 max_secret_len,
                                 &mut scrub_overlap,
@@ -1227,7 +1231,7 @@ fn tls_connection_thread(
                 }
             }
             if !headers_sent && !header_buf.is_empty() {
-                let (scrubbed, _) = crate::secret::scrub(&header_buf, secrets);
+                let (scrubbed, _) = crate::secret::scrub(&header_buf, &sni, secrets);
                 let rewritten = rewrite_connection_close(&scrubbed);
                 tls.write_all(&rewritten)?;
             }
@@ -1415,6 +1419,7 @@ fn tcp_forward_thread(
 fn write_scrubbed_chunk(
     out: &mut impl Write,
     chunk: &[u8],
+    hostname: &str,
     secrets: &[SecretBinding],
     max_secret_len: usize,
     scrub_overlap: &mut Vec<u8>,
@@ -1427,7 +1432,7 @@ fn write_scrubbed_chunk(
     let mut window = std::mem::take(scrub_overlap);
     window.extend_from_slice(chunk);
 
-    let (scrubbed, scrub_count) = crate::secret::scrub(&window, secrets);
+    let (scrubbed, scrub_count) = crate::secret::scrub(&window, hostname, secrets);
     if scrub_count > 0 {
         log::info!("BODY SCRUBBED: {scrub_count} value(s)");
     }
@@ -1840,7 +1845,11 @@ mod tests {
     // --- write_scrubbed_chunk overlap tests ---
 
     fn make_secret(placeholder: &str, real: &str) -> SecretBinding {
-        SecretBinding::new_unchecked(placeholder.to_string(), real.to_string(), vec![])
+        SecretBinding::new_unchecked(
+            placeholder.to_string(),
+            real.to_string(),
+            vec!["upstream.test".to_string()],
+        )
     }
 
     #[test]
@@ -1851,6 +1860,7 @@ mod tests {
         write_scrubbed_chunk(
             &mut out,
             b"prefix SECRET123 suffix",
+            "upstream.test",
             &[secret],
             9,
             &mut overlap,
@@ -1878,12 +1888,21 @@ mod tests {
         write_scrubbed_chunk(
             &mut out,
             b"prefix ABCDE",
+            "upstream.test",
             &[secret.clone()],
             10,
             &mut overlap,
         )
         .unwrap();
-        write_scrubbed_chunk(&mut out, b"FGHIJ suffix", &[secret], 10, &mut overlap).unwrap();
+        write_scrubbed_chunk(
+            &mut out,
+            b"FGHIJ suffix",
+            "upstream.test",
+            &[secret],
+            10,
+            &mut overlap,
+        )
+        .unwrap();
         out.extend_from_slice(&overlap);
         let text = String::from_utf8_lossy(&out);
         assert!(
@@ -1898,7 +1917,15 @@ mod tests {
         let secret = make_secret("ph", "TOKEN");
         let mut out = Vec::new();
         let mut overlap = Vec::new();
-        write_scrubbed_chunk(&mut out, b"data TOKEN", &[secret], 5, &mut overlap).unwrap();
+        write_scrubbed_chunk(
+            &mut out,
+            b"data TOKEN",
+            "upstream.test",
+            &[secret],
+            5,
+            &mut overlap,
+        )
+        .unwrap();
         // Flush overlap (may contain the tail)
         out.extend_from_slice(&overlap);
         let text = String::from_utf8_lossy(&out);
@@ -1909,7 +1936,15 @@ mod tests {
     fn scrub_chunk_no_secrets_passthrough() {
         let mut out = Vec::new();
         let mut overlap = Vec::new();
-        write_scrubbed_chunk(&mut out, b"hello world", &[], 0, &mut overlap).unwrap();
+        write_scrubbed_chunk(
+            &mut out,
+            b"hello world",
+            "upstream.test",
+            &[],
+            0,
+            &mut overlap,
+        )
+        .unwrap();
         assert_eq!(out, b"hello world");
         assert!(overlap.is_empty());
     }
@@ -1924,6 +1959,7 @@ mod tests {
         write_scrubbed_chunk(
             &mut out,
             b"got ALPHA and BETA here",
+            "upstream.test",
             &[s1, s2],
             max_len,
             &mut overlap,

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -278,14 +278,25 @@ fn try_inject_basic(value: &[u8], secrets: &[&SecretBinding]) -> Option<(String,
 
 /// Replace real secret values with placeholders in an HTTP response.
 ///
+/// Only secrets whose `allowed_hosts` include `hostname` are scrubbed, so a
+/// response from one host can't expose a secret scoped to another. Mirrors
+/// the host filtering in [`inject`].
+///
 /// Best-effort: matches literal bytes only. See module docs for limitations.
 ///
 /// Returns the (possibly modified) response data and the number of scrubs.
-pub fn scrub(data: &[u8], secrets: &[SecretBinding]) -> (Vec<u8>, usize) {
+pub fn scrub(data: &[u8], hostname: &str, secrets: &[SecretBinding]) -> (Vec<u8>, usize) {
     let mut result = data.to_vec();
     let mut count = 0;
 
     for secret in secrets {
+        if !secret
+            .allowed_hosts()
+            .iter()
+            .any(|allowed| allowed.eq_ignore_ascii_case(hostname))
+        {
+            continue;
+        }
         if let Some((replaced, n)) = byte_replace(
             &result,
             secret.real_value().as_bytes(),
@@ -455,7 +466,7 @@ mod tests {
     fn scrub_removes_real_value() {
         let secrets = vec![test_binding()];
         let resp = b"Token: ghp_RealSecretValue99 is active";
-        let (result, count) = scrub(resp, &secrets);
+        let (result, count) = scrub(resp, "api.github.com", &secrets);
         assert_eq!(count, 1);
         assert!(result.windows(18).any(|w| w == b"redan_ph_test_1234"));
         assert!(!result.windows(21).any(|w| w == b"ghp_RealSecretValue99"));
@@ -465,7 +476,7 @@ mod tests {
     fn scrub_no_match_returns_unchanged() {
         let secrets = vec![test_binding()];
         let resp = b"HTTP/1.1 200 OK\r\n\r\nno secrets here";
-        let (result, count) = scrub(resp, &secrets);
+        let (result, count) = scrub(resp, "api.github.com", &secrets);
         assert_eq!(count, 0);
         assert_eq!(result, resp);
     }
@@ -474,9 +485,20 @@ mod tests {
     fn scrub_handles_binary_data() {
         let secrets = vec![test_binding()];
         let resp: Vec<u8> = vec![0xFF, 0xFE, 0x00, 0x01]; // invalid UTF-8
-        let (result, count) = scrub(&resp, &secrets);
+        let (result, count) = scrub(&resp, "api.github.com", &secrets);
         assert_eq!(count, 0);
         assert_eq!(result, resp); // must not corrupt
+    }
+
+    #[test]
+    fn scrub_skips_disallowed_host() {
+        // A response from a host the secret is not bound to must not be
+        // scrubbed: scrub() filters on allowed_hosts the way inject() does.
+        let secrets = vec![test_binding()];
+        let resp = b"Token: ghp_RealSecretValue99 is active";
+        let (result, count) = scrub(resp, "evil.com", &secrets);
+        assert_eq!(count, 0);
+        assert_eq!(result, resp);
     }
 
     #[test]

--- a/tests/adversarial.rs
+++ b/tests/adversarial.rs
@@ -296,7 +296,7 @@ fn b01_scrub_catches_literal_secret_in_body() {
         &["api.github.com"],
     )];
     let resp = b"HTTP/1.1 200 OK\r\n\r\n{\"token\": \"ghp_SuperSecret123\"}";
-    let (result, count) = scrub(resp, &secrets);
+    let (result, count) = scrub(resp, "api.github.com", &secrets);
     assert_eq!(count, 1);
     assert!(
         !result
@@ -327,7 +327,7 @@ fn b02_scrub_does_not_catch_base64_encoded_secret() {
     )];
     let encoded = base64::engine::general_purpose::STANDARD.encode("ghp_SuperSecret123");
     let resp = format!("HTTP/1.1 200 OK\r\n\r\n{{\"encoded\": \"{encoded}\"}}");
-    let (result, count) = scrub(resp.as_bytes(), &secrets);
+    let (result, count) = scrub(resp.as_bytes(), "api.github.com", &secrets);
     assert_eq!(
         count, 0,
         "base64-encoded secret should NOT be caught (known limitation)"
@@ -354,7 +354,7 @@ fn b03_scrub_does_not_catch_url_encoded_secret() {
     // URL-encode: ghp_SuperSecret123 -> ghp%5FSuperSecret123
     let encoded = "ghp%5FSuperSecret123";
     let resp = format!("HTTP/1.1 200 OK\r\n\r\ntoken={encoded}");
-    let (result, count) = scrub(resp.as_bytes(), &secrets);
+    let (result, count) = scrub(resp.as_bytes(), "api.github.com", &secrets);
     assert_eq!(
         count, 0,
         "URL-encoded secret should NOT be caught (known limitation)"
@@ -373,7 +373,7 @@ fn b04_scrub_requires_exact_full_match() {
         &["api.github.com"],
     )];
     let resp = b"HTTP/1.1 200 OK\r\n\r\nPrefix: ghp_Super is common";
-    let (result, count) = scrub(resp, &secrets);
+    let (result, count) = scrub(resp, "api.github.com", &secrets);
     assert_eq!(count, 0, "partial match must not trigger scrub");
     assert_eq!(result, resp);
 }
@@ -393,7 +393,7 @@ fn b05_scrub_preserves_binary_response() {
     let binary: Vec<u8> = (0..256).map(|i| i as u8).collect();
     resp.extend_from_slice(&binary);
 
-    let (result, count) = scrub(&resp, &secrets);
+    let (result, count) = scrub(&resp, "api.github.com", &secrets);
     assert_eq!(count, 0);
     assert_eq!(result, resp, "binary response must be byte-identical");
 }
@@ -408,7 +408,7 @@ fn b06_scrub_catches_secret_in_response_headers() {
         &["api.github.com"],
     )];
     let resp = b"HTTP/1.1 200 OK\r\nX-Auth-Echo: ghp_SuperSecret123\r\n\r\nok";
-    let (result, count) = scrub(resp, &secrets);
+    let (result, count) = scrub(resp, "api.github.com", &secrets);
     assert_eq!(count, 1);
     assert!(
         !result
@@ -941,7 +941,7 @@ fn h05_scrub_catches_secret_in_reassembled_chunked_response() {
     // (relay_upstream does this before passing to scrub)
     let resp = b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n\
                  13\r\nghp_SuperSecret123\r\n0\r\n\r\n";
-    let (result, count) = scrub(resp, &secrets);
+    let (result, count) = scrub(resp, "api.github.com", &secrets);
     assert_eq!(
         count, 1,
         "scrub must catch secret in buffered chunked response"
@@ -973,7 +973,7 @@ fn h06_scrub_does_not_catch_gzip_compressed_secret() {
     let mut resp = b"HTTP/1.1 200 OK\r\nContent-Encoding: gzip\r\n\r\n".to_vec();
     resp.extend_from_slice(&compressed);
 
-    let (_, count) = scrub(&resp, &secrets);
+    let (_, count) = scrub(&resp, "api.github.com", &secrets);
     assert_eq!(
         count, 0,
         "gzip-compressed secrets NOT caught (known limitation, mitigated by Accept-Encoding stripping)"


### PR DESCRIPTION
`inject()` already checks each secret's `allowed_hosts` before injecting,
but `scrub()` ran every secret against every response regardless of the
host it came from. It's not exploitable today (the proxy rejects
non-allowed hosts before any response body is read), but it's the kind of
asymmetry that becomes a real leak the moment allowlist enforcement moves
or loosens, which is what #42 asked to harden.

Adds a `hostname` parameter to `scrub()` that skips secrets whose
`allowed_hosts` don't match, exactly mirroring `inject()`. The SNI host is
threaded through the three proxy call sites and `write_scrubbed_chunk()`.
New unit test `scrub_skips_disallowed_host` locks in the behavior; the
existing scrub tests now pass a matching host.

Closes #42

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented hostname-aware secret scrubbing that only removes secrets when accessing hosts on the secret's allowlist.

* **Tests**
  * Updated security tests to validate hostname-aware secret scrubbing behavior across various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->