### PR TITLE
refactor(image): pipe docker export to tar without a shell

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -312,22 +312,42 @@ fn import_docker_inner(name: &str, docker_image: &str, pull: bool) -> io::Result
         .trim()
         .to_string();
 
-    let export = std::process::Command::new("sh")
-        .args([
-            "-c",
-            &format!("docker export {cid} | tar xf - -C {}", dest.display()),
-        ])
-        .status();
+    // Stream the container filesystem straight into the destination:
+    // `docker export <cid>` piped into `tar -x`. Wiring the two processes
+    // directly instead of through `sh -c` keeps the destination path out of a
+    // shell, so a path with spaces or shell metacharacters can't break or
+    // inject into the command.
+    let export_ok = match std::process::Command::new("docker")
+        .args(["export", &cid])
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+    {
+        Ok(mut exporter) => {
+            let tar_ok = exporter.stdout.take().is_some_and(|stdout| {
+                std::process::Command::new("tar")
+                    .arg("xf")
+                    .arg("-")
+                    .arg("-C")
+                    .arg(&dest)
+                    .stdin(std::process::Stdio::from(stdout))
+                    .status()
+                    .is_ok_and(|s| s.success())
+            });
+            // Reap docker after tar has drained the pipe.
+            let docker_ok = exporter.wait().is_ok_and(|s| s.success());
+            tar_ok && docker_ok
+        }
+        Err(_) => false,
+    };
+
+    // Remove the container regardless of export outcome.
     let _ = std::process::Command::new("docker")
         .args(["rm", &cid])
         .status();
 
-    match export {
-        Ok(s) if s.success() => {}
-        _ => {
-            let _ = fs::remove_dir_all(&dest);
-            return Err(io::Error::other("docker export failed"));
-        }
+    if !export_ok {
+        let _ = fs::remove_dir_all(&dest);
+        return Err(io::Error::other("docker export failed"));
     }
 
     // Verify it looks like a rootfs

--- a/src/image.rs
+++ b/src/image.rs
@@ -317,27 +317,44 @@ fn import_docker_inner(name: &str, docker_image: &str, pull: bool) -> io::Result
     // directly instead of through `sh -c` keeps the destination path out of a
     // shell, so a path with spaces or shell metacharacters can't break or
     // inject into the command.
-    let export_ok = match std::process::Command::new("docker")
+    // Each step reports its own failure so the error names the operation that
+    // actually broke (docker spawn, tar spawn, tar extraction, or docker exit)
+    // instead of blaming "docker export" for everything.
+    let export_result: Result<(), String> = match std::process::Command::new("docker")
         .args(["export", &cid])
         .stdout(std::process::Stdio::piped())
         .spawn()
     {
+        Err(e) => Err(format!("could not start docker export: {e}")),
         Ok(mut exporter) => {
-            let tar_ok = exporter.stdout.take().is_some_and(|stdout| {
-                std::process::Command::new("tar")
-                    .arg("xf")
-                    .arg("-")
-                    .arg("-C")
-                    .arg(&dest)
-                    .stdin(std::process::Stdio::from(stdout))
-                    .status()
-                    .is_ok_and(|s| s.success())
-            });
+            let tar_result = exporter
+                .stdout
+                .take()
+                .ok_or_else(|| "docker export produced no stdout".to_string())
+                .and_then(|stdout| {
+                    match std::process::Command::new("tar")
+                        .arg("xf")
+                        .arg("-")
+                        .arg("-C")
+                        .arg(&dest)
+                        .stdin(std::process::Stdio::from(stdout))
+                        .status()
+                    {
+                        Err(e) => Err(format!("could not run tar: {e}")),
+                        Ok(s) if s.success() => Ok(()),
+                        Ok(s) => Err(format!("tar extraction failed ({s})")),
+                    }
+                });
             // Reap docker after tar has drained the pipe.
-            let docker_ok = exporter.wait().is_ok_and(|s| s.success());
-            tar_ok && docker_ok
+            let docker_result = match exporter.wait() {
+                Err(e) => Err(format!("could not wait on docker export: {e}")),
+                Ok(s) if s.success() => Ok(()),
+                Ok(s) => Err(format!("docker export failed ({s})")),
+            };
+            // Prefer tar's error: if tar dies, docker fails on the broken pipe
+            // too, but tar's failure is the root cause worth surfacing.
+            tar_result.and(docker_result)
         }
-        Err(_) => false,
     };
 
     // Remove the container regardless of export outcome.
@@ -345,9 +362,9 @@ fn import_docker_inner(name: &str, docker_image: &str, pull: bool) -> io::Result
         .args(["rm", &cid])
         .status();
 
-    if !export_ok {
+    if let Err(msg) = export_result {
         let _ = fs::remove_dir_all(&dest);
-        return Err(io::Error::other("docker export failed"));
+        return Err(io::Error::other(msg));
     }
 
     // Verify it looks like a rootfs


### PR DESCRIPTION
`import_docker_inner` ran `docker export <cid> | tar xf - -C <dest>` through `sh -c`, interpolating the destination path (which includes `$XDG_DATA_HOME` / `$HOME`) into the shell string. A storage path with spaces or shell metacharacters would break the command or inject into it.

This wires the two processes directly: `docker export`'s piped stdout feeds `tar`'s stdin, and the destination goes to `tar` as an argument, so no shell can reinterpret it. `tar` drains the pipe before `docker` is reaped, so there's no deadlock, and the container is still removed regardless of outcome.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of Docker container export by changing how the filesystem is extracted and validating both the export and extraction steps.
  * Ensures cleanup behavior is consistent even when the export operation fails, and returns clearer errors on failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->