### PR TITLE
feat(trust): gate working-directory redan.toml behind trust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -822,6 +822,7 @@ dependencies = [
  "minijinja",
  "rcgen",
  "redan",
+ "ring",
  "rustls",
  "rustls-pemfile",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,8 @@ thiserror = "2.0.18"
 shell-words = "1.1.1"
 getrandom = "0.4"
 base64 = "0.22.1"
+# Already in the tree via rustls; used directly for SHA-256 of trusted configs.
+ring = "0.17"
 
 [features]
 test-support = []

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -152,3 +152,64 @@ Redan rejects requests where the Host header does not match the TLS
 SNI hostname (HTTP 421 Misdirected Request). This blocks domain
 fronting in most cases. Residual risk: if the allowed host itself
 routes internally based on other headers or path components.
+
+## Configuration trust
+
+A `redan.toml` in the working directory is not like the guest: redan's host
+process reads it, before the VM boots, with your own authority. It can read host
+environment variables and Vault (`env://` / `vault://` secrets), mount host
+paths into the guest, set a host `rootfs`, forward host-local ports, and write
+host log files. So it is a second trust boundary. A hostile `redan.toml` in a
+repo you cloned could exfiltrate your credentials or expose host files, none of
+which the VM sandbox would stop, because the config runs before the sandbox.
+
+Redan gates this. A config that stays within a safe subset (`image`, `command`,
+guest `env`, `[network] allow`, and a project-workspace mount) needs no trust,
+since none of it touches host authority. A config that reaches for any of the
+above must be trusted first:
+
+- Interactively, redan prints exactly what the config would be allowed to do and
+  asks before acting on it.
+- Out of band, `redan trust` records the config (and `redan untrust` removes it).
+- Without a terminal and without prior trust (CI, detached runs), redan does not
+  use the config and tells you to run `redan trust`. It is never auto-trusted.
+
+Trust is keyed by a SHA-256 of the file's contents, so editing the file (for
+example, a compromised agent rewriting the mounted `redan.toml`) invalidates
+trust until you review and trust it again. The safe subset is enforced by
+exhaustively classifying every config field, so a field added in a future
+release cannot silently load without trust.
+
+### What configuration trust does NOT protect against
+
+Trust is a machine-local consent record, not a cryptographic signature. The
+store (`~/.local/state/redan/trust.json`, mode 0600) is protected only by
+filesystem permissions. It defends against two things: the sandboxed guest
+agent, which can edit the mounted `redan.toml` but cannot reach the host-side
+store (and any edit changes the content hash, so trust drops); and accidentally
+acting on a config you never reviewed.
+
+It does **not** defend against a process already running as your user on the
+host. That process can rewrite the store, re-trust a malicious file, or read
+your secrets and `~/.ssh` directly without going near redan; it has won by other
+means, and no trust record would stop it. This is the same posture as direnv,
+mise, and git's `safe.directory`. Signing the config would defend a
+*legitimately signed* file against tampering, but redan's actual risk is a
+config you have not reviewed, which a signature you happen to trust does not
+address.
+
+#### Staged credentials in the guest
+
+When redan stages an agent's credential files (Claude's `.credentials.json`,
+Pi's `auth.json`) into the guest rootfs, those are real secrets written to the
+guest filesystem as plaintext. This is the one exception to "secrets never touch
+the guest": a deliberate fallback for agents that need their own credential
+files. The network-injected path (`ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`)
+keeps the secret host-side and is preferred.
+
+#### Literal secrets on disk in detached mode
+
+A detached session (`--detach`) serializes its resolved config to
+`daemon_config.json` (mode 0600, in a 0700 directory) until the daemon reads and
+unlinks it. A literal `--secret VALUE:host` therefore touches disk briefly;
+`env://` and `vault://` references do not, since only the reference is written.

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,3 +1,4 @@
 pub(crate) mod doctor;
 pub(crate) mod exec;
 pub(crate) mod init;
+pub(crate) mod trust;

--- a/src/cmd/trust.rs
+++ b/src/cmd/trust.rs
@@ -1,0 +1,184 @@
+//! Trust gate for working-directory configs, plus `redan trust` / `untrust`.
+//!
+//! `load_config` is the only blessed way to load a cwd config: it classifies
+//! the config and, if it reaches host authority, requires trust (granted via an
+//! interactive prompt here or out of band with `redan trust`). `config::discover`
+//! is raw and must not be acted on directly.
+
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+
+use redan::config::{self, ConfigSource};
+use redan::trust::{self, Capability, Decision};
+
+/// Discover the config and apply the trust gate.
+///
+/// Returns the `(path, config)` to use, or `None` only when there is no config
+/// file at all. A project config that is present but needs trust it doesn't have
+/// is a hard stop (the process exits), never a silent fall-through to
+/// auto-detect: a `redan.toml` you can see should be used or refused, not
+/// quietly replaced by something else.
+pub(crate) fn load_config() -> Option<(PathBuf, config::Config)> {
+    let config::DiscoveredConfig {
+        path,
+        content,
+        config,
+        source,
+    } = config::discover()?;
+
+    // The user's own config (~/.config/redan/config.toml) is implicitly trusted.
+    if source == ConfigSource::User {
+        return Some((path, config));
+    }
+
+    let project_root = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let caps = trust::analyze(&config, &project_root);
+    let already_trusted = trust::is_trusted(&path, content.as_bytes());
+    let interactive = redan::terminal::stdin_is_tty();
+
+    match trust::decide(!caps.is_empty(), already_trusted, interactive) {
+        Decision::Load => Some((path, config)),
+        Decision::Prompt => {
+            print_capabilities(&path, &caps);
+            if confirm("Trust this config and continue?") {
+                if let Err(e) = trust::trust(&path, content.as_bytes()) {
+                    eprintln!("warning: could not record trust: {e}");
+                }
+                Some((path, config))
+            } else {
+                eprintln!("{} left untrusted; not running.", path.display());
+                std::process::exit(1);
+            }
+        }
+        Decision::Skip => {
+            eprintln!(
+                "{} needs trust and this is a non-interactive session.",
+                path.display()
+            );
+            print_capabilities(&path, &caps);
+            eprintln!("Review it, then run `redan trust` to allow it.");
+            std::process::exit(1);
+        }
+    }
+}
+
+/// `redan trust [path]`: review what a config grants, then record it as trusted.
+pub(crate) fn trust_cmd(path_arg: Option<&str>) {
+    let path = resolve_config_path(path_arg);
+    let content = read_or_exit(&path);
+    let cfg: config::Config = toml::from_str(&content).unwrap_or_else(|e| {
+        eprintln!("error: failed to parse {}: {e}", path.display());
+        std::process::exit(1);
+    });
+
+    let project_root = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let caps = trust::analyze(&cfg, &project_root);
+    if caps.is_empty() {
+        eprintln!(
+            "{} uses only safe settings (no host access).",
+            path.display()
+        );
+    } else {
+        print_capabilities(&path, &caps);
+    }
+
+    match trust::trust(&path, content.as_bytes()) {
+        Ok(()) => eprintln!("trusted {}", path.display()),
+        Err(e) => {
+            eprintln!("error: cannot record trust: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+/// `redan untrust [path]`: remove a config from the trust store.
+pub(crate) fn untrust_cmd(path_arg: Option<&str>) {
+    let path = resolve_config_path(path_arg);
+    match trust::untrust(&path) {
+        Ok(()) => eprintln!("no longer trusting {}", path.display()),
+        Err(e) => {
+            eprintln!("error: cannot update trust store: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+fn resolve_config_path(path_arg: Option<&str>) -> PathBuf {
+    PathBuf::from(path_arg.unwrap_or("redan.toml"))
+}
+
+fn read_or_exit(path: &Path) -> String {
+    std::fs::read_to_string(path).unwrap_or_else(|e| {
+        eprintln!("error: cannot read {}: {e}", path.display());
+        std::process::exit(1);
+    })
+}
+
+fn print_capabilities(path: &Path, caps: &[Capability]) {
+    eprintln!("{} would be allowed to:", path.display());
+    for line in describe_all(caps) {
+        eprintln!("  - {line}");
+    }
+}
+
+/// Human-readable summary lines for a capability list.
+fn describe_all(caps: &[Capability]) -> Vec<String> {
+    caps.iter().map(describe).collect()
+}
+
+fn describe(cap: &Capability) -> String {
+    match cap {
+        Capability::Rootfs(p) => {
+            format!("use {p} as the guest root  [exposes that host directory to the guest]")
+        }
+        Capability::AuditLog(p) => format!("write an audit log to host path {p}"),
+        Capability::LogFile(p) => format!("write logs to host path {p}"),
+        Capability::Forward(s) => {
+            format!("forward port {s} to a host-local service  [reachable from the guest]")
+        }
+        Capability::EnvSecret { name, var } => {
+            format!("read host env var ${var} (secret {name})  [reads your shell environment]")
+        }
+        Capability::VaultSecret { name, reference } => {
+            format!("fetch {reference} from Vault (secret {name})  [uses your Vault token]")
+        }
+        Capability::OutOfTreeMount { source, target, .. } => {
+            format!("mount {source} -> {target}  [path OUTSIDE the project directory]")
+        }
+    }
+}
+
+fn confirm(question: &str) -> bool {
+    eprint!("{question} [y/N] ");
+    let _ = std::io::stderr().flush();
+    let mut answer = String::new();
+    if std::io::stdin().read_line(&mut answer).is_err() {
+        return false;
+    }
+    matches!(answer.trim().to_ascii_lowercase().as_str(), "y" | "yes")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn describe_flags_dangerous_capabilities() {
+        let caps = vec![
+            Capability::EnvSecret {
+                name: "K".into(),
+                var: "AWS_SECRET".into(),
+            },
+            Capability::OutOfTreeMount {
+                name: "m".into(),
+                source: "/home/u/.ssh".into(),
+                target: "/ssh".into(),
+            },
+        ];
+        let lines = describe_all(&caps);
+        assert!(lines[0].contains("AWS_SECRET"));
+        assert!(lines[0].contains("shell environment"));
+        assert!(lines[1].contains("/home/u/.ssh"));
+        assert!(lines[1].contains("OUTSIDE"));
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -202,25 +202,58 @@ fn read_claude_settings(path: &Path) -> Option<Vec<String>> {
     )
 }
 
-/// Search for a config file. Returns the path and parsed config,
-/// or None if no config file exists.
-pub fn find_and_load() -> Option<(PathBuf, Config)> {
-    let candidates = config_paths();
-    for path in candidates {
-        if path.is_file() {
-            match load(&path) {
-                Ok(config) => {
-                    if !config.secrets.is_empty() {
-                        warn_if_world_readable(&path);
-                    }
-                    return Some((path, config));
-                }
-                Err(e) => {
-                    eprintln!("error: failed to parse {}: {e}", path.display());
-                    std::process::exit(1);
-                }
-            }
+/// Where a discovered config came from.
+///
+/// Project configs (a cwd `redan.toml`) are trust-gated; user configs
+/// (`~/.config/redan/config.toml`) are implicitly trusted, since you placed
+/// them in your own home directory.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfigSource {
+    Project,
+    User,
+}
+
+/// A config file found on disk.
+///
+/// Read once, so the raw bytes are available for the trust hash.
+pub struct DiscoveredConfig {
+    pub path: PathBuf,
+    pub content: String,
+    pub config: Config,
+    pub source: ConfigSource,
+}
+
+/// Find and read the first existing config file.
+///
+/// Looks for a cwd `redan.toml`, then `~/.config/redan/config.toml`, reading it
+/// once so the raw content is available alongside the parsed config. Exits on a
+/// parse error; returns `None` if no config file exists.
+///
+/// This is raw discovery: a project config is **not** trust-checked here.
+/// Callers that act on a cwd config must go through the trust gate
+/// (`cmd::trust::load_config`) rather than calling this directly.
+pub fn discover() -> Option<DiscoveredConfig> {
+    for (path, source) in config_candidates() {
+        if !path.is_file() {
+            continue;
         }
+        let content = std::fs::read_to_string(&path).unwrap_or_else(|e| {
+            eprintln!("error: cannot read {}: {e}", path.display());
+            std::process::exit(1);
+        });
+        let config: Config = toml::from_str(&content).unwrap_or_else(|e| {
+            eprintln!("error: failed to parse {}: {e}", path.display());
+            std::process::exit(1);
+        });
+        if !config.secrets.is_empty() {
+            warn_if_world_readable(&path);
+        }
+        return Some(DiscoveredConfig {
+            path,
+            content,
+            config,
+            source,
+        });
     }
     None
 }
@@ -245,22 +278,16 @@ fn warn_if_world_readable(path: &Path) {
 #[cfg(not(unix))]
 fn warn_if_world_readable(_path: &Path) {}
 
-fn config_paths() -> Vec<PathBuf> {
-    let mut paths = vec![PathBuf::from("redan.toml")];
+fn config_candidates() -> Vec<(PathBuf, ConfigSource)> {
+    let mut paths = vec![(PathBuf::from("redan.toml"), ConfigSource::Project)];
     if let Some(config_dir) = dirs_path() {
-        paths.push(config_dir.join("config.toml"));
+        paths.push((config_dir.join("config.toml"), ConfigSource::User));
     }
     paths
 }
 
 fn dirs_path() -> Option<PathBuf> {
     std::env::var_os("HOME").map(|home| Path::new(&home).join(".config/redan"))
-}
-
-fn load(path: &Path) -> Result<Config, String> {
-    let content = std::fs::read_to_string(path)
-        .map_err(|e| format!("cannot read {}: {e}", path.display()))?;
-    toml::from_str(&content).map_err(|e| format!("{e}"))
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,4 +21,5 @@ pub mod session;
 pub mod templates;
 pub mod terminal;
 pub mod tls;
+pub mod trust;
 pub mod vm;

--- a/src/main.rs
+++ b/src/main.rs
@@ -281,6 +281,23 @@ enum Cli {
         #[arg(long)]
         claude: bool,
     },
+
+    /// Review and trust a redan.toml so redan will act on it
+    ///
+    /// A working-directory redan.toml that reads host env vars or Vault, mounts
+    /// host paths, sets a rootfs, forwards host ports, or writes host logs must
+    /// be trusted first. Trust is a machine-local record keyed by the file's
+    /// contents, so editing the file requires trusting it again.
+    Trust {
+        /// Path to the config (default: ./redan.toml)
+        path: Option<String>,
+    },
+
+    /// Remove a redan.toml from the trust store
+    Untrust {
+        /// Path to the config (default: ./redan.toml)
+        path: Option<String>,
+    },
 }
 
 #[derive(clap::Subcommand)]
@@ -486,6 +503,8 @@ fn main() {
         },
         Cli::Logs { session, follow } => logs(session.as_deref(), follow),
         Cli::Init { claude } => cmd::init::run(claude),
+        Cli::Trust { path } => cmd::trust::trust_cmd(path.as_deref()),
+        Cli::Untrust { path } => cmd::trust::untrust_cmd(path.as_deref()),
         Cli::Sessions { action } => match action {
             None => {
                 let sessions = session::list_sessions();
@@ -602,7 +621,7 @@ struct ExecArgs {
 }
 
 fn exec_command(args: ExecArgs) {
-    let config_file = config::find_and_load();
+    let config_file = cmd::trust::load_config();
     if let Some((ref path, _)) = config_file {
         eprintln!("config: {}", path.display());
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -917,9 +917,10 @@ fn run_command(args: RunArgs) {
 
     // The agent profile is a set of defaults; a project redan.toml layers on
     // top (overriding on conflict), then CLI flags override both in `launch`.
-    // Precedence: agent defaults < redan.toml < CLI. With no redan.toml the
-    // merge is a no-op.
-    let config = match config::find_and_load() {
+    // Precedence: agent defaults < redan.toml < CLI. Loading goes through the
+    // trust gate, so a redan.toml that reaches host authority must be trusted
+    // or the gate stops here. With no redan.toml the merge is a no-op.
+    let config = match cmd::trust::load_config() {
         Some((path, project)) => {
             eprintln!("config: {}", path.display());
             config::overlay(auto.config, project)

--- a/src/trust.rs
+++ b/src/trust.rs
@@ -1,0 +1,578 @@
+//! Trust for working-directory `redan.toml` files.
+//!
+//! A `redan.toml` discovered in the current directory is a host-context input:
+//! the host process reads it, before the VM boots, with the operator's own
+//! authority. It can read host env vars and Vault (`env://` / `vault://`
+//! secrets), mount host paths into the guest, set a host `rootfs`, forward
+//! host-local ports, and write host log files. So a config that reaches for any
+//! of that must be explicitly trusted before redan acts on it. A config that
+//! stays within a safe subset (image, command, guest env, allowlist, a project
+//! workspace mount) needs no trust, since none of it touches host authority.
+//!
+//! Trust is a machine-local consent record, **not** a cryptographic signature.
+//! The store is `~/.local/state/redan/trust.json`, protected only by filesystem
+//! permissions. It defends against the sandboxed guest agent (which can edit the
+//! mounted `redan.toml` but cannot reach the host-side store, and any edit
+//! changes the content hash, so trust is invalidated) and against accidentally
+//! using an unreviewed config. It does **not** defend against a process already
+//! running as your user on the host, which has won by other means. See
+//! `docs/security-model.md`.
+
+use std::collections::BTreeMap;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use crate::config::Config;
+
+/// A capability in a config that reaches host authority and therefore needs
+/// trust. The list doubles as the summary shown when granting trust.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Capability {
+    /// `rootfs = "<path>"`: a host directory used as the guest root.
+    Rootfs(String),
+    /// `audit_log = "<path>"`: a host file redan writes to.
+    AuditLog(String),
+    /// `log_file = "<path>"`: a host file redan writes to.
+    LogFile(String),
+    /// `[network] forward`: exposes a host-local port to the guest.
+    Forward(String),
+    /// `[secrets.<name>] value = "env://<var>"`: reads a host env var.
+    EnvSecret { name: String, var: String },
+    /// `[secrets.<name>] value = "vault://<ref>"`: reads from Vault.
+    VaultSecret { name: String, reference: String },
+    /// `[mount.<name>]` whose source resolves outside the project directory.
+    OutOfTreeMount {
+        name: String,
+        source: String,
+        target: String,
+    },
+}
+
+/// The capabilities in `cfg` that require trust. Empty means the config is
+/// within the safe subset and may load without trust.
+///
+/// `project_root` is the directory the config was loaded from; a mount whose
+/// source resolves inside it is project-local and safe.
+#[must_use]
+pub fn analyze(cfg: &Config, project_root: &Path) -> Vec<Capability> {
+    // Exhaustive destructure, intentionally without `..`: adding a field to
+    // Config forces a classification decision right here. Do NOT add `..` to
+    // silence a future compile error -- that would let a new capability load
+    // without trust (fail-open). Anything not provably sandbox-safe must be
+    // pushed as a Capability.
+    let Config {
+        // Safe: sandbox-confined, or policy that cannot exfiltrate on its own.
+        image: _,       // a named local image
+        command: _,     // runs inside the VM
+        timeout: _,     // tuning
+        interactive: _, // tuning
+        env: _,         // guest-side env vars
+        rootfs,
+        audit_log,
+        log_file,
+        network,
+        secrets,
+        mount,
+    } = cfg;
+
+    let mut caps = Vec::new();
+
+    if let Some(path) = rootfs {
+        caps.push(Capability::Rootfs(path.clone()));
+    }
+    if let Some(path) = audit_log {
+        caps.push(Capability::AuditLog(path.clone()));
+    }
+    if let Some(path) = log_file {
+        caps.push(Capability::LogFile(path.clone()));
+    }
+    // network.allow only widens reachable hosts; without a secret it cannot
+    // exfiltrate, so it is safe. forward exposes a host-local port to the guest.
+    for spec in &network.forward {
+        caps.push(Capability::Forward(spec.clone()));
+    }
+    for (name, secret) in secrets {
+        // Schemes per provider::resolve_secret_value. A literal value is the
+        // config author's own data and reads nothing from the host, so it is
+        // safe; env:// and vault:// read the operator's ambient credentials.
+        if let Some(var) = secret.value.strip_prefix("env://") {
+            caps.push(Capability::EnvSecret {
+                name: name.clone(),
+                var: var.to_string(),
+            });
+        } else if let Some(reference) = secret.value.strip_prefix("vault://") {
+            caps.push(Capability::VaultSecret {
+                name: name.clone(),
+                reference: reference.to_string(),
+            });
+        }
+    }
+    for (name, m) in mount {
+        if !is_within_project(project_root, &m.source) {
+            caps.push(Capability::OutOfTreeMount {
+                name: name.clone(),
+                source: m.source.clone(),
+                target: m.target.clone().unwrap_or_else(|| "/workspace".into()),
+            });
+        }
+    }
+
+    caps
+}
+
+/// Whether `source` (resolved relative to `project_root`) lies inside
+/// `project_root`. Fails safe: if either path cannot be canonicalized, returns
+/// `false`, so the mount is treated as out-of-tree and requires trust.
+fn is_within_project(project_root: &Path, source: &str) -> bool {
+    let Ok(root) = project_root.canonicalize() else {
+        return false;
+    };
+    let raw = Path::new(source);
+    let candidate = if raw.is_absolute() {
+        raw.to_path_buf()
+    } else {
+        root.join(raw)
+    };
+    candidate.canonicalize().is_ok_and(|c| c.starts_with(&root))
+}
+
+/// What to do with a discovered config once it has been classified.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Decision {
+    /// Safe subset, or already trusted: load and use it.
+    Load,
+    /// Needs trust, interactive session: ask the user (show the summary, prompt).
+    Prompt,
+    /// Needs trust but it isn't trusted and we can't ask: do not use the file.
+    Skip,
+}
+
+/// Decide what to do with a discovered config.
+///
+/// `needs_trust` is `!analyze(...).is_empty()`. A safe or already-trusted config
+/// just loads; otherwise an interactive session prompts and a non-interactive
+/// one skips. Trust is granted only via the prompt or `redan trust`; a config
+/// is never auto-trusted without a TTY.
+#[must_use]
+pub const fn decide(needs_trust: bool, already_trusted: bool, interactive: bool) -> Decision {
+    if !needs_trust || already_trusted {
+        Decision::Load
+    } else if interactive {
+        Decision::Prompt
+    } else {
+        Decision::Skip
+    }
+}
+
+// --- Trust store ---
+
+/// canonical config path -> `"sha256:<hex>"` of the trusted contents.
+type Store = BTreeMap<String, String>;
+
+const STORE_FILE: &str = "trust.json";
+
+/// `~/.local/state/redan/trust.json` (honoring `XDG_STATE_HOME`).
+fn store_path() -> Option<PathBuf> {
+    let base = std::env::var_os("XDG_STATE_HOME")
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".local/state")))?;
+    Some(base.join("redan").join(STORE_FILE))
+}
+
+/// SHA-256 of `content`, prefixed for algorithm agility.
+#[must_use]
+pub fn fingerprint(content: &[u8]) -> String {
+    use std::fmt::Write as _;
+    let digest = ring::digest::digest(&ring::digest::SHA256, content);
+    let mut hex = String::with_capacity(digest.as_ref().len() * 2);
+    for byte in digest.as_ref() {
+        let _ = write!(hex, "{byte:02x}");
+    }
+    format!("sha256:{hex}")
+}
+
+/// Canonical absolute path as the store key, or `None` if it can't resolve.
+fn canonical_key(path: &Path) -> Option<String> {
+    path.canonicalize()
+        .ok()
+        .map(|p| p.to_string_lossy().into_owned())
+}
+
+fn read_store(store_path: &Path) -> Store {
+    let Ok(content) = std::fs::read_to_string(store_path) else {
+        return Store::new();
+    };
+    serde_json::from_str(&content).unwrap_or_else(|e| {
+        log::warn!(
+            "trust store {} is unreadable ({e}); treating all configs as untrusted",
+            store_path.display()
+        );
+        Store::new()
+    })
+}
+
+fn write_store(store_path: &Path, store: &Store) -> io::Result<()> {
+    if let Some(dir) = store_path.parent() {
+        std::fs::create_dir_all(dir)?;
+    }
+    let json = serde_json::to_string_pretty(store).map_err(io::Error::other)?;
+
+    // Write to a temp sibling then rename, so a crash mid-write can't corrupt
+    // the store. 0600: the store isn't secret, but there's no reason for other
+    // users on a shared host to read or poke it.
+    let tmp = store_path.with_file_name(format!("{STORE_FILE}.tmp"));
+    {
+        use std::io::Write as _;
+        let mut opts = std::fs::OpenOptions::new();
+        opts.write(true).create(true).truncate(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt as _;
+            opts.mode(0o600);
+        }
+        let mut file = opts.open(&tmp)?;
+        file.write_all(json.as_bytes())?;
+        file.sync_all()?;
+    }
+    std::fs::rename(&tmp, store_path)
+}
+
+fn is_trusted_in(store_path: &Path, config_path: &Path, content: &[u8]) -> bool {
+    let Some(key) = canonical_key(config_path) else {
+        return false;
+    };
+    read_store(store_path)
+        .get(&key)
+        .is_some_and(|stored| *stored == fingerprint(content))
+}
+
+fn trust_in(store_path: &Path, config_path: &Path, content: &[u8]) -> io::Result<()> {
+    let key = canonical_key(config_path).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("cannot resolve {}", config_path.display()),
+        )
+    })?;
+    let mut store = read_store(store_path);
+    store.insert(key, fingerprint(content));
+    write_store(store_path, &store)
+}
+
+fn untrust_in(store_path: &Path, config_path: &Path) -> io::Result<()> {
+    let key = canonical_key(config_path).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("cannot resolve {}", config_path.display()),
+        )
+    })?;
+    let mut store = read_store(store_path);
+    store.remove(&key);
+    write_store(store_path, &store)
+}
+
+fn no_store_dir() -> io::Error {
+    io::Error::new(
+        io::ErrorKind::NotFound,
+        "cannot determine state directory (set HOME or XDG_STATE_HOME)",
+    )
+}
+
+/// Whether `config_path` with these exact `content` bytes is trusted.
+///
+/// Hash the same bytes you go on to parse, so the trust decision and the load
+/// see identical content (no check-then-read gap).
+#[must_use]
+pub fn is_trusted(config_path: &Path, content: &[u8]) -> bool {
+    store_path().is_some_and(|sp| is_trusted_in(&sp, config_path, content))
+}
+
+/// Record `config_path` with these `content` bytes as trusted.
+pub fn trust(config_path: &Path, content: &[u8]) -> io::Result<()> {
+    let sp = store_path().ok_or_else(no_store_dir)?;
+    trust_in(&sp, config_path, content)
+}
+
+/// Remove `config_path` from the trust store.
+pub fn untrust(config_path: &Path) -> io::Result<()> {
+    let sp = store_path().ok_or_else(no_store_dir)?;
+    untrust_in(&sp, config_path)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::config::{Config, MountConfig, NetworkConfig, SecretConfig};
+
+    fn write(path: &Path, content: &str) {
+        std::fs::write(path, content).unwrap();
+    }
+
+    // --- fingerprint ---
+
+    #[test]
+    fn fingerprint_is_stable_and_prefixed() {
+        let a = fingerprint(b"hello");
+        let b = fingerprint(b"hello");
+        assert_eq!(a, b);
+        assert!(a.starts_with("sha256:"));
+        // SHA-256 hex is 64 chars after the prefix.
+        assert_eq!(a.len(), "sha256:".len() + 64);
+    }
+
+    #[test]
+    fn fingerprint_changes_with_content() {
+        assert_ne!(fingerprint(b"hello"), fingerprint(b"hello!"));
+    }
+
+    // --- decide ---
+
+    #[test]
+    fn safe_config_always_loads() {
+        for trusted in [false, true] {
+            for tty in [false, true] {
+                assert_eq!(decide(false, trusted, tty), Decision::Load);
+            }
+        }
+    }
+
+    #[test]
+    fn trusted_config_loads() {
+        assert_eq!(decide(true, true, false), Decision::Load);
+    }
+
+    #[test]
+    fn untrusted_interactive_prompts() {
+        assert_eq!(decide(true, false, true), Decision::Prompt);
+    }
+
+    #[test]
+    fn untrusted_noninteractive_skips() {
+        // Never auto-trust without a TTY (grant via the prompt or `redan trust`).
+        assert_eq!(decide(true, false, false), Decision::Skip);
+    }
+
+    // --- store round-trip via the *_in cores (no env mutation) ---
+
+    #[test]
+    fn trust_then_is_trusted() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = dir.path().join("trust.json");
+        let cfg = dir.path().join("redan.toml");
+        write(&cfg, "image = \"x\"\n");
+        let content = std::fs::read(&cfg).unwrap();
+
+        assert!(!is_trusted_in(&store, &cfg, &content));
+        trust_in(&store, &cfg, &content).unwrap();
+        assert!(is_trusted_in(&store, &cfg, &content));
+    }
+
+    #[test]
+    fn editing_content_invalidates_trust() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = dir.path().join("trust.json");
+        let cfg = dir.path().join("redan.toml");
+        write(&cfg, "image = \"x\"\n");
+        trust_in(&store, &cfg, &std::fs::read(&cfg).unwrap()).unwrap();
+
+        // An edit (e.g. by the guest agent) changes the bytes -> not trusted.
+        write(&cfg, "image = \"x\"\nrootfs = \"/\"\n");
+        assert!(!is_trusted_in(&store, &cfg, &std::fs::read(&cfg).unwrap()));
+    }
+
+    #[test]
+    fn untrust_removes_trust() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = dir.path().join("trust.json");
+        let cfg = dir.path().join("redan.toml");
+        write(&cfg, "image = \"x\"\n");
+        let content = std::fs::read(&cfg).unwrap();
+        trust_in(&store, &cfg, &content).unwrap();
+        untrust_in(&store, &cfg).unwrap();
+        assert!(!is_trusted_in(&store, &cfg, &content));
+    }
+
+    #[test]
+    fn missing_store_is_untrusted_not_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = dir.path().join("does-not-exist.json");
+        let cfg = dir.path().join("redan.toml");
+        write(&cfg, "image = \"x\"\n");
+        assert!(!is_trusted_in(&store, &cfg, &std::fs::read(&cfg).unwrap()));
+    }
+
+    #[test]
+    fn corrupt_store_is_untrusted_not_a_panic() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = dir.path().join("trust.json");
+        write(&store, "{ this is not valid json");
+        let cfg = dir.path().join("redan.toml");
+        write(&cfg, "image = \"x\"\n");
+        assert!(!is_trusted_in(&store, &cfg, &std::fs::read(&cfg).unwrap()));
+    }
+
+    #[test]
+    fn store_written_with_owner_only_perms() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = dir.path().join("trust.json");
+        let cfg = dir.path().join("redan.toml");
+        write(&cfg, "image = \"x\"\n");
+        trust_in(&store, &cfg, &std::fs::read(&cfg).unwrap()).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&store).unwrap().permissions().mode();
+            assert_eq!(mode & 0o777, 0o600, "got mode {:o}", mode & 0o777);
+        }
+    }
+
+    // --- analyze (capability classification) ---
+
+    fn empty_config() -> Config {
+        Config::default()
+    }
+
+    #[test]
+    fn safe_subset_needs_no_trust() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut cfg = Config {
+            image: Some("claude-code".into()),
+            command: Some("claude".into()),
+            interactive: Some(true),
+            timeout: Some(3600),
+            network: NetworkConfig {
+                allow: vec!["api.anthropic.com".into()],
+                forward: vec![],
+            },
+            ..empty_config()
+        };
+        cfg.env.insert("HOME".into(), "/home/dev".into());
+        // A literal secret reads nothing from the host.
+        cfg.secrets.insert(
+            "K".into(),
+            SecretConfig {
+                value: "sk-literal".into(),
+                hosts: vec!["api.anthropic.com".into()],
+            },
+        );
+        // The project workspace mount.
+        cfg.mount.insert(
+            "workspace".into(),
+            MountConfig {
+                source: ".".into(),
+                target: Some("/workspace".into()),
+                read_only: false,
+            },
+        );
+        assert!(analyze(&cfg, dir.path()).is_empty());
+    }
+
+    #[test]
+    fn env_and_vault_secrets_require_trust() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut cfg = empty_config();
+        cfg.secrets.insert(
+            "A".into(),
+            SecretConfig {
+                value: "env://AWS_SECRET_ACCESS_KEY".into(),
+                hosts: vec!["evil.example".into()],
+            },
+        );
+        cfg.secrets.insert(
+            "B".into(),
+            SecretConfig {
+                value: "vault://ci/github#token".into(),
+                hosts: vec!["github.com".into()],
+            },
+        );
+        let caps = analyze(&cfg, dir.path());
+        assert!(caps.contains(&Capability::EnvSecret {
+            name: "A".into(),
+            var: "AWS_SECRET_ACCESS_KEY".into(),
+        }));
+        assert!(caps.contains(&Capability::VaultSecret {
+            name: "B".into(),
+            reference: "ci/github#token".into(),
+        }));
+    }
+
+    #[test]
+    fn rootfs_audit_log_and_forward_require_trust() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = Config {
+            rootfs: Some("/srv/rootfs".into()),
+            audit_log: Some("/var/log/redan.jsonl".into()),
+            log_file: Some("/tmp/redan.log".into()),
+            network: NetworkConfig {
+                allow: vec![],
+                forward: vec!["9222".into()],
+            },
+            ..empty_config()
+        };
+        let caps = analyze(&cfg, dir.path());
+        assert!(caps.contains(&Capability::Rootfs("/srv/rootfs".into())));
+        assert!(caps.contains(&Capability::AuditLog("/var/log/redan.jsonl".into())));
+        assert!(caps.contains(&Capability::LogFile("/tmp/redan.log".into())));
+        assert!(caps.contains(&Capability::Forward("9222".into())));
+    }
+
+    #[test]
+    fn in_tree_mount_is_safe_out_of_tree_needs_trust() {
+        let project = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        // A real subdirectory of the project (must exist to canonicalize).
+        let sub = project.path().join("src");
+        std::fs::create_dir(&sub).unwrap();
+
+        let mut cfg = empty_config();
+        cfg.mount.insert(
+            "workspace".into(),
+            MountConfig {
+                source: ".".into(),
+                target: Some("/workspace".into()),
+                read_only: false,
+            },
+        );
+        cfg.mount.insert(
+            "code".into(),
+            MountConfig {
+                source: "src".into(),
+                target: Some("/code".into()),
+                read_only: false,
+            },
+        );
+        cfg.mount.insert(
+            "secrets".into(),
+            MountConfig {
+                source: outside.path().to_string_lossy().into_owned(),
+                target: Some("/host".into()),
+                read_only: false,
+            },
+        );
+
+        let caps = analyze(&cfg, project.path());
+        // Only the out-of-tree mount is flagged.
+        assert_eq!(caps.len(), 1, "caps: {caps:?}");
+        assert!(matches!(
+            &caps[0],
+            Capability::OutOfTreeMount { name, target, .. }
+                if name == "secrets" && target == "/host"
+        ));
+    }
+
+    #[test]
+    fn unresolvable_mount_source_fails_safe_as_out_of_tree() {
+        let project = tempfile::tempdir().unwrap();
+        let mut cfg = empty_config();
+        cfg.mount.insert(
+            "ghost".into(),
+            MountConfig {
+                source: "does-not-exist-yet".into(),
+                target: Some("/ghost".into()),
+                read_only: false,
+            },
+        );
+        // Can't canonicalize -> treated as out-of-tree (requires trust).
+        assert_eq!(analyze(&cfg, project.path()).len(), 1);
+    }
+}


### PR DESCRIPTION
## The gap

A `redan.toml` in the working directory isn't like the guest: redan's host process reads it, before the VM boots, with your own authority. It can read host env vars and Vault (`env://`/`vault://` secrets), mount host paths into the guest, set a host `rootfs`, forward host-local ports, and write host log files. So it's a second trust boundary the design didn't acknowledge: a hostile `redan.toml` in a repo you cloned could exfiltrate your credentials or expose host files, none of which the VM sandbox would stop, because the config runs *before* the sandbox.

## What this does

A config within a **safe subset** (`image`, `command`, guest `env`, `[network] allow`, a project-workspace mount) loads with no trust, since none of it touches host authority. A config that reaches for anything else must be trusted first:

- interactive → redan prints exactly what the config would be allowed to do and asks before acting on it
- `redan trust [path]` records it out of band (`redan untrust` removes it)
- non-interactive without prior trust (CI, detached) → it stops with a notice, never auto-trusted

A `redan.toml` you can see is either used or refused, never silently swapped for auto-detect.

## Design notes

- **Content-hash trust**, not path-only. Trust is keyed by SHA-256 of the file's contents (`ring`, already in the tree), so a compromised agent editing the mounted `redan.toml` invalidates trust on the next run. Store is `~/.local/state/redan/trust.json`, atomic write, `0600`, fails closed on missing/corrupt.
- **Fail-safe classification.** `trust::analyze` destructures `Config` *exhaustively* (no `..`), so a field added later won't compile until it's classified as safe or trust-requiring. We can't fail open by forgetting one.
- **Stricter than mise on purpose.** No `--trust` flag (trust is granted only via the prompt or `redan trust`), and no CI auto-trust (mise trusts CI checkouts; for a secret-handling tool that's backwards).
- **Honest about what it is.** Trust is a machine-local consent record, not a signature. It defends against the sandboxed agent (can't reach the host store) and accidental use of unreviewed configs; it does **not** defend against a same-uid attacker on the host, who has won by other means. Documented as such in `docs/security-model.md`, alongside two folded-in audit caveats (staged credentials are plaintext in-guest; literal `--secret` values touch disk briefly in detached mode).

## Tests

Trust store round-trip and content-invalidation, corrupt/missing store fails closed, `0600` perms, the fail-safe `analyze` classification (env/vault/rootfs/forward/out-of-tree all flagged; safe subset empty), the `decide` truth table, and the consent rendering. Verified live: `redan trust` shows the flagged summary and records; trusted configs load; untrusted non-interactive stops with exit 1.

## Coordination

This branches off `main`, where `run_command` doesn't read `redan.toml`, so only `exec_command` is gated. `find_and_load` is removed (the gate is the only un-bypassable path), so when #62 (config-layering) lands, `run_command` must route through `cmd::trust::load_config` too. Whichever rebases second won't compile until it does.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configuration trust mechanism for `redan.toml`, including `redan trust` and `redan untrust` commands.
  * Introduced a persistent, content-hash-based trust store to control whether host-impacting configuration is allowed.
  * When trust is required, the CLI may prompt interactively or skip/exit in non-interactive mode.

* **Documentation**
  * Expanded the security model docs with a new “Configuration trust” section covering trust boundaries, safe subsets, and exceptions.

* **Refactor**
  * Updated config discovery/loading to support trust-gated behavior and clearer source tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->