### PR TITLE
Trust UX polish: gate before run output + README docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,39 @@ Uses virtio-fs for host directory sharing. The guest has read-write
 access by default. Append `:ro` for read-only. Git is your safety net
 for recovering from unwanted changes to mounted directories.
 
+## Config trust
+
+A `redan.toml` in your working directory is read by redan on the *host*,
+before the VM boots, with your privileges. So a `redan.toml` from a repo you
+cloned could read your environment, mount your home directory, or write host
+files, none of which the sandbox would catch, because it runs before the
+sandbox starts. redan trust-gates it.
+
+A config that only sets safe things (`image`, `command`, guest `env`,
+`[network] allow`, a literal secret, or a mount inside the project) loads with
+no prompt. A config that reaches for host authority has to be trusted first:
+
+- reading host env vars or Vault (`env://` / `vault://` secrets)
+- mounting a path outside the project, or setting `rootfs`
+- forwarding a host-local port, or writing a host `audit_log` / `log_file`
+
+When redan hits one of those and the config isn't trusted, it prints exactly
+what the config would be allowed to do and, in an interactive session, asks
+before continuing. Or trust it ahead of time:
+
+```bash
+redan trust              # review ./redan.toml, then trust it
+redan trust path/to/redan.toml
+redan untrust            # revoke
+```
+
+Trust is keyed by a hash of the file's contents (in
+`~/.local/state/redan/trust.json`), so editing the config requires trusting it
+again. It's a local consent record, not a signature: it guards against an
+unreviewed config and against the sandboxed agent rewriting the mounted file,
+not against someone who already has your user account. See
+[docs/security-model.md](docs/security-model.md).
+
 ## Image management
 
 ```bash

--- a/src/main.rs
+++ b/src/main.rs
@@ -905,6 +905,12 @@ fn resolve_run_target(agent: Option<&str>) -> redan::auto_detect::AutoDetected {
 /// `redan run <agent>`: launch a named agent profile (or auto-detect when
 /// no agent is given), then funnel into the shared `launch` path.
 fn run_command(args: RunArgs) {
+    // Trust-gate the project redan.toml up front, before any agent setup,
+    // messages, or image build, so an untrusted config stops here cleanly
+    // instead of after a wall of setup output. load_config exits the process
+    // if the config needs trust it doesn't have.
+    let project_config = cmd::trust::load_config();
+
     let auto = resolve_run_target(args.agent.as_deref());
 
     build_image_if_needed(&auto);
@@ -917,10 +923,9 @@ fn run_command(args: RunArgs) {
 
     // The agent profile is a set of defaults; a project redan.toml layers on
     // top (overriding on conflict), then CLI flags override both in `launch`.
-    // Precedence: agent defaults < redan.toml < CLI. Loading goes through the
-    // trust gate, so a redan.toml that reaches host authority must be trusted
-    // or the gate stops here. With no redan.toml the merge is a no-op.
-    let config = match cmd::trust::load_config() {
+    // Precedence: agent defaults < redan.toml < CLI. With no redan.toml the
+    // merge is a no-op.
+    let config = match project_config {
         Some((path, project)) => {
             eprintln!("config: {}", path.display());
             config::overlay(auto.config, project)


### PR DESCRIPTION
Two small follow-ups to the config-trust work (#64):

**`fix(run)`:** `run_command` printed the agent's setup messages (and could build the image) *before* reaching the trust gate, so an untrusted `redan.toml` stopped only after a wall of output. Moves `load_config` to the top of `run_command` so the prompt/stop happens first. (`exec` already gated first.)

**`docs`:** adds a **Config trust** section to the README, what a cwd `redan.toml` is, the safe subset vs. what needs trust, the `redan trust`/`untrust` commands, and the "consent record, not a signature" framing.

Two clean commits; rebase-merge keeps both conventional subjects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Config trust" section describing trust verification for `redan.toml` configurations.

* **New Features**
  * Configuration trust-gating now validates `redan.toml` files accessing host authority (environment, secrets, mounting, port forwarding).
  * Interactive review flow via `redan trust` / `redan untrust` commands for configurations requiring verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->