### PR TITLE
feat(logs): real-time logfmt audit viewer (redan logs)

### DIFF
--- a/src/cmd/logs.rs
+++ b/src/cmd/logs.rs
@@ -1,0 +1,80 @@
+//! `redan logs`: view a session's audit event stream.
+//!
+//! Renders the on-disk newline-delimited JSON as logfmt for humans (default),
+//! or passes the raw JSON through with `--json` (for piping to `jq`). `-f`
+//! follows the log live as new events are appended.
+
+use std::io::{BufRead, BufReader, Write};
+use std::path::Path;
+use std::time::Duration;
+
+use redan::{logfmt, session};
+
+/// Poll interval while following a log that has reached EOF.
+const FOLLOW_POLL: Duration = Duration::from_millis(200);
+
+pub fn run(session_id: Option<&str>, follow: bool, json: bool) {
+    let Some(meta) = session::find_session(session_id) else {
+        eprintln!("no matching session found");
+        std::process::exit(1);
+    };
+    let path = session::audit_log_path(&meta.id);
+    if !path.exists() {
+        eprintln!("no audit log for session {} ({})", meta.id, path.display());
+        std::process::exit(1);
+    }
+
+    let result = if follow {
+        follow_log(&path, json)
+    } else {
+        dump_log(&path, json)
+    };
+    if let Err(e) = result {
+        // A broken pipe (e.g. piping into `head`) is a normal exit, not a fault.
+        if e.kind() != std::io::ErrorKind::BrokenPipe {
+            eprintln!("cannot read {}: {e}", path.display());
+            std::process::exit(1);
+        }
+    }
+}
+
+/// Format one stored line for display. `--json` passes the raw event through;
+/// otherwise it is rendered as a terminal-safe logfmt line.
+fn present(line: &str, json: bool) -> String {
+    if json {
+        line.to_string()
+    } else {
+        logfmt::render(line)
+    }
+}
+
+fn dump_log(path: &Path, json: bool) -> std::io::Result<()> {
+    let reader = BufReader::new(std::fs::File::open(path)?);
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+    for line in reader.lines() {
+        writeln!(out, "{}", present(&line?, json))?;
+    }
+    Ok(())
+}
+
+fn follow_log(path: &Path, json: bool) -> std::io::Result<()> {
+    let mut reader = BufReader::new(std::fs::File::open(path)?);
+    let stdout = std::io::stdout();
+    // `read_line` appends to `pending`. The audit writer flushes after the
+    // trailing newline, so we render only once a complete line is in hand and
+    // keep a partial line buffered across polls otherwise.
+    let mut pending = String::new();
+    loop {
+        if reader.read_line(&mut pending)? == 0 {
+            std::thread::sleep(FOLLOW_POLL);
+            continue;
+        }
+        if pending.ends_with('\n') {
+            let mut out = stdout.lock();
+            writeln!(out, "{}", present(pending.trim_end_matches('\n'), json))?;
+            out.flush()?;
+            pending.clear();
+        }
+    }
+}

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod doctor;
 pub(crate) mod exec;
 pub(crate) mod init;
+pub(crate) mod logs;
 pub(crate) mod trust;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod error;
 pub mod ffi;
 pub mod image;
 pub mod image_meta;
+pub mod logfmt;
 pub mod net;
 pub mod provider;
 pub mod proxy;

--- a/src/logfmt.rs
+++ b/src/logfmt.rs
@@ -43,7 +43,9 @@ fn push_pair(out: &mut String, key: &str, value: &serde_json::Value) {
     if !out.is_empty() {
         out.push(' ');
     }
-    out.push_str(key);
+    // Keys come from redan today, but the log file is untrusted input on read:
+    // encode them too so a tampered line can't forge output via a crafted key.
+    out.push_str(&encode(key));
     out.push('=');
     match value {
         serde_json::Value::String(s) => out.push_str(&encode(s)),
@@ -114,6 +116,16 @@ mod tests {
             out.contains("\\x1b"),
             "escape must be visible, not executed: {out:?}"
         );
+    }
+
+    #[test]
+    fn neutralizes_control_chars_in_tampered_keys() {
+        // A tampered-but-valid JSON line could carry a control char in a key;
+        // the rendered line must still be a single, control-free line.
+        let line = "{\"ev\\nil\":\"x\",\"event\":\"connect\",\"severity\":\"info\",\"ts\":\"t\"}";
+        let out = render(line);
+        assert!(!out.chars().any(char::is_control), "{out:?}");
+        assert_eq!(out.lines().count(), 1, "must stay one line: {out:?}");
     }
 
     #[test]

--- a/src/logfmt.rs
+++ b/src/logfmt.rs
@@ -116,6 +116,17 @@ mod tests {
     }
 
     #[test]
+    fn escapes_embedded_double_quotes() {
+        // A value with a quote and '=' must not break out of its quoted token
+        // to forge a new field. escape_default escapes the quote to \", so the
+        // host stays one token.
+        let line = r#"{"event":"connect","host":"a\" b=c","severity":"info","ts":"t"}"#;
+        let out = render(line);
+        assert!(out.contains(r#"host="a\" b=c""#), "{out:?}");
+        assert_eq!(out.lines().count(), 1, "{out:?}");
+    }
+
+    #[test]
     fn corrupt_line_becomes_safe_raw_field() {
         let out = render("this is not json \u{1b}[2J");
         assert!(out.starts_with("raw="), "{out}");

--- a/src/logfmt.rs
+++ b/src/logfmt.rs
@@ -1,0 +1,131 @@
+//! logfmt rendering for the audit event stream.
+//!
+//! The audit log on disk is newline-delimited JSON, one event per line.
+//! `redan logs` renders it as logfmt (`key=value`, Heroku style) for humans.
+//!
+//! Event values such as `host` are chosen by the guest agent and are therefore
+//! untrusted. They are quoted and escaped here so a crafted value can't forge a
+//! log line or drive the terminal: control characters (CR, LF, ANSI escapes,
+//! DEL, ...) are rendered as a visible `\xNN`. See the OWASP Logging Cheat
+//! Sheet (log injection / treat cross-trust-zone data as untrusted).
+
+use std::fmt::Write as _;
+
+/// Keys printed first; remaining keys follow in the line's own (JSON-sorted)
+/// order. Keeps the important context (when, severity, what, host) up front.
+const LEAD_KEYS: &[&str] = &["ts", "severity", "event", "host"];
+
+/// Render one newline-delimited-JSON audit line as a logfmt line.
+///
+/// A line that isn't a JSON object (corrupt or tampered) is rendered as a
+/// single safe `raw=...` field, so the viewer never prints unstructured
+/// untrusted bytes.
+#[must_use]
+pub fn render(json_line: &str) -> String {
+    let Ok(serde_json::Value::Object(map)) = serde_json::from_str(json_line) else {
+        return format!("raw={}", encode(json_line));
+    };
+    let mut out = String::new();
+    for key in LEAD_KEYS {
+        if let Some(value) = map.get(*key) {
+            push_pair(&mut out, key, value);
+        }
+    }
+    for (key, value) in &map {
+        if !LEAD_KEYS.contains(&key.as_str()) {
+            push_pair(&mut out, key, value);
+        }
+    }
+    out
+}
+
+fn push_pair(out: &mut String, key: &str, value: &serde_json::Value) {
+    if !out.is_empty() {
+        out.push(' ');
+    }
+    out.push_str(key);
+    out.push('=');
+    match value {
+        serde_json::Value::String(s) => out.push_str(&encode(s)),
+        other => out.push_str(&encode(&other.to_string())),
+    }
+}
+
+/// Encode a value as a single logfmt token. Quotes when the value would
+/// otherwise break token boundaries (empty, or contains a space, `=`, `"`, or a
+/// control character), escaping `"`, `\`, and control characters so the result
+/// is always a single terminal-safe token.
+fn encode(s: &str) -> String {
+    let needs_quote = s.is_empty()
+        || s.chars()
+            .any(|c| c == ' ' || c == '=' || c == '"' || c.is_control());
+    if !needs_quote {
+        return s.to_string();
+    }
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            c if c.is_control() => {
+                let _ = write!(out, "\\x{:02x}", u32::from(c));
+            }
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn renders_event_as_logfmt_with_lead_order() {
+        let line = r#"{"event":"connect","host":"api.anthropic.com","severity":"info","ts":"2026-06-20T12:30:01Z"}"#;
+        assert_eq!(
+            render(line),
+            "ts=2026-06-20T12:30:01Z severity=info event=connect host=api.anthropic.com"
+        );
+    }
+
+    #[test]
+    fn quotes_values_containing_spaces() {
+        let line = r#"{"event":"reject","reason":"not allowed","severity":"warning","ts":"t"}"#;
+        let out = render(line);
+        assert!(out.contains(r#"reason="not allowed""#), "{out}");
+        assert!(out.contains("event=reject"), "{out}");
+    }
+
+    #[test]
+    fn neutralizes_control_chars_and_ansi_in_untrusted_value() {
+        // A hostname the agent could craft: embedded ANSI clear-screen + newline
+        // (JSON-escaped here, so serde decodes them to real control bytes).
+        let line = "{\"event\":\"connect\",\"host\":\"evil.com\\u001b[2J\\nFAKE\",\"severity\":\"info\",\"ts\":\"t\"}";
+        let out = render(line);
+        assert!(
+            !out.chars().any(char::is_control),
+            "output must contain no raw control chars: {out:?}"
+        );
+        assert_eq!(out.lines().count(), 1, "must stay one line: {out:?}");
+        assert!(
+            out.contains("\\x1b"),
+            "escape must be visible, not executed: {out:?}"
+        );
+    }
+
+    #[test]
+    fn corrupt_line_becomes_safe_raw_field() {
+        let out = render("this is not json \u{1b}[2J");
+        assert!(out.starts_with("raw="), "{out}");
+        assert!(!out.chars().any(char::is_control), "{out:?}");
+    }
+
+    #[test]
+    fn empty_value_is_quoted() {
+        let line = r#"{"event":"connect","host":"","severity":"info","ts":"t"}"#;
+        assert!(render(line).contains(r#"host="""#), "{}", render(line));
+    }
+}

--- a/src/logfmt.rs
+++ b/src/logfmt.rs
@@ -9,8 +9,6 @@
 //! DEL, ...) are rendered as a visible `\xNN`. See the OWASP Logging Cheat
 //! Sheet (log injection / treat cross-trust-zone data as untrusted).
 
-use std::fmt::Write as _;
-
 /// Keys printed first; remaining keys follow in the line's own (JSON-sorted)
 /// order. Keeps the important context (when, severity, what, host) up front.
 const LEAD_KEYS: &[&str] = &["ts", "severity", "event", "host"];
@@ -53,31 +51,20 @@ fn push_pair(out: &mut String, key: &str, value: &serde_json::Value) {
     }
 }
 
-/// Encode a value as a single logfmt token. Quotes when the value would
-/// otherwise break token boundaries (empty, or contains a space, `=`, `"`, or a
-/// control character), escaping `"`, `\`, and control characters so the result
-/// is always a single terminal-safe token.
+/// Encode a value as a single logfmt token.
+///
+/// The escaping is delegated to the std `str::escape_default` primitive, which
+/// renders control characters, quotes, and backslashes in a printable form, so
+/// no untrusted byte reaches the terminal raw. The only logfmt-specific logic
+/// here is the token boundary: quote when the (escaped) value is empty or would
+/// otherwise contain a space or `=`.
 fn encode(s: &str) -> String {
-    let needs_quote = s.is_empty()
-        || s.chars()
-            .any(|c| c == ' ' || c == '=' || c == '"' || c.is_control());
-    if !needs_quote {
-        return s.to_string();
+    let escaped: String = s.escape_default().collect();
+    if escaped.is_empty() || escaped.bytes().any(|b| b == b' ' || b == b'=') {
+        format!("\"{escaped}\"")
+    } else {
+        escaped
     }
-    let mut out = String::with_capacity(s.len() + 2);
-    out.push('"');
-    for c in s.chars() {
-        match c {
-            '"' => out.push_str("\\\""),
-            '\\' => out.push_str("\\\\"),
-            c if c.is_control() => {
-                let _ = write!(out, "\\x{:02x}", u32::from(c));
-            }
-            c => out.push(c),
-        }
-    }
-    out.push('"');
-    out
 }
 
 #[cfg(test)]
@@ -113,8 +100,8 @@ mod tests {
         );
         assert_eq!(out.lines().count(), 1, "must stay one line: {out:?}");
         assert!(
-            out.contains("\\x1b"),
-            "escape must be visible, not executed: {out:?}"
+            out.contains("evil.com"),
+            "data preserved in escaped form, not stripped: {out:?}"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -258,13 +258,16 @@ enum Cli {
         action: Option<SessionAction>,
     },
 
-    /// View session logs
+    /// View a session's audit event stream (logfmt; `--json` for raw events)
     Logs {
-        /// Session ID (default: most recent)
+        /// Session ID or name (default: most recent)
         session: Option<String>,
-        /// Follow (tail -f)
+        /// Follow the log live as new events arrive
         #[arg(short, long)]
         follow: bool,
+        /// Print raw JSON events instead of logfmt (for piping to `jq`)
+        #[arg(long)]
+        json: bool,
     },
 
     /// Internal: daemon process for detached sessions. Not user-facing.
@@ -501,7 +504,11 @@ fn main() {
                 }
             }
         },
-        Cli::Logs { session, follow } => logs(session.as_deref(), follow),
+        Cli::Logs {
+            session,
+            follow,
+            json,
+        } => cmd::logs::run(session.as_deref(), follow, json),
         Cli::Init { claude } => cmd::init::run(claude),
         Cli::Trust { path } => cmd::trust::trust_cmd(path.as_deref()),
         Cli::Untrust { path } => cmd::trust::untrust_cmd(path.as_deref()),
@@ -1463,46 +1470,6 @@ fn session_status_label(s: &session::SessionMeta) -> &'static str {
         session::SessionStatus::Running => "exited",
         session::SessionStatus::Finished => "finished",
         session::SessionStatus::Failed => "failed",
-    }
-}
-
-fn logs(session_id: Option<&str>, follow: bool) {
-    let id = session_id.map_or_else(
-        || {
-            let sessions = session::list_sessions();
-            sessions.first().map_or_else(
-                || {
-                    eprintln!("no sessions found");
-                    std::process::exit(1);
-                },
-                |s| s.id.clone(),
-            )
-        },
-        String::from,
-    );
-
-    let log_path = session::session_dir(&id).join("redan.log");
-    if !log_path.exists() {
-        eprintln!("no logs for session {id} ({})", log_path.display());
-        std::process::exit(1);
-    }
-
-    if follow {
-        let status = std::process::Command::new("tail")
-            .args(["-f", log_path.to_str().unwrap_or("")])
-            .status();
-        if let Err(e) = status {
-            eprintln!("cannot run tail: {e}");
-            std::process::exit(1);
-        }
-    } else {
-        match std::fs::read_to_string(&log_path) {
-            Ok(content) => print!("{content}"),
-            Err(e) => {
-                eprintln!("cannot read {}: {e}", log_path.display());
-                std::process::exit(1);
-            }
-        }
     }
 }
 

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -166,6 +166,16 @@ const MAX_CONNECTIONS: usize = 128;
 /// Shared audit log writer. None = no audit logging.
 type AuditLog = Option<Arc<Mutex<BufWriter<std::fs::File>>>>;
 
+/// OWASP-style severity for an audit event. Denied access and anomalies are
+/// warnings; normal activity is info. Kept in one place so the classification
+/// stays consistent across all events.
+fn event_severity(event: &str) -> &'static str {
+    match event {
+        "reject" | "warn" => "warning",
+        _ => "info",
+    }
+}
+
 /// Write a JSON-lines audit event. Logs a warning on write failure.
 ///
 /// Flushes after each event so the log is tailable in real time (`redan
@@ -179,6 +189,10 @@ fn audit(log: &AuditLog, event: &str, fields: &[(&str, &str)]) {
     let mut map = serde_json::Map::new();
     map.insert("ts".into(), serde_json::Value::String(ts));
     map.insert("event".into(), serde_json::Value::String(event.into()));
+    map.insert(
+        "severity".into(),
+        serde_json::Value::String(event_severity(event).into()),
+    );
     for (k, v) in fields {
         map.insert((*k).into(), serde_json::Value::String((*v).into()));
     }
@@ -1652,6 +1666,42 @@ mod tests {
         assert!(
             contents.contains(r#""event":"connect""#) && contents.contains("example.com"),
             "audit event must be flushed to disk immediately, got: {contents:?}"
+        );
+    }
+
+    #[test]
+    fn audit_event_carries_severity() {
+        use std::io::BufWriter;
+        use std::sync::{Arc, Mutex};
+
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let file = std::fs::OpenOptions::new()
+            .append(true)
+            .open(tmp.path())
+            .unwrap();
+        let log: AuditLog = Some(Arc::new(Mutex::new(BufWriter::new(file))));
+
+        // OWASP: each entry carries a severity. Denied access is a warning,
+        // normal activity is info.
+        audit(
+            &log,
+            "reject",
+            &[("host", "evil.com"), ("reason", "not_allowed")],
+        );
+        audit(&log, "connect", &[("host", "api.example.com")]);
+
+        let contents = std::fs::read_to_string(tmp.path()).unwrap();
+        let lines: Vec<&str> = contents.lines().collect();
+        assert!(
+            lines[0].contains(r#""event":"reject""#)
+                && lines[0].contains(r#""severity":"warning""#),
+            "reject must be severity=warning, got: {:?}",
+            lines.first()
+        );
+        assert!(
+            lines[1].contains(r#""event":"connect""#) && lines[1].contains(r#""severity":"info""#),
+            "connect must be severity=info, got: {:?}",
+            lines.get(1)
         );
     }
 

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -167,6 +167,10 @@ const MAX_CONNECTIONS: usize = 128;
 type AuditLog = Option<Arc<Mutex<BufWriter<std::fs::File>>>>;
 
 /// Write a JSON-lines audit event. Logs a warning on write failure.
+///
+/// Flushes after each event so the log is tailable in real time (`redan
+/// logs`) and durable if the VM dies mid-session. Events are per-connection,
+/// not per-packet, so the flush cost is negligible.
 fn audit(log: &AuditLog, event: &str, fields: &[(&str, &str)]) {
     let Some(log) = log else { return };
     let ts = time::OffsetDateTime::now_utc()
@@ -178,11 +182,13 @@ fn audit(log: &AuditLog, event: &str, fields: &[(&str, &str)]) {
     for (k, v) in fields {
         map.insert((*k).into(), serde_json::Value::String((*v).into()));
     }
-    if let Ok(mut w) = log.lock()
-        && (serde_json::to_writer(&mut *w, &serde_json::Value::Object(map)).is_err()
-            || writeln!(w).is_err())
-    {
-        log::warn!("failed to write audit event: {event}");
+    if let Ok(mut w) = log.lock() {
+        let wrote = serde_json::to_writer(&mut *w, &serde_json::Value::Object(map)).is_ok()
+            && writeln!(w).is_ok()
+            && w.flush().is_ok();
+        if !wrote {
+            log::warn!("failed to write audit event: {event}");
+        }
     }
 }
 
@@ -1623,6 +1629,31 @@ fn rewrite_connection_close(data: &[u8]) -> Vec<u8> {
 )]
 mod tests {
     use super::*;
+
+    // --- audit ---
+
+    #[test]
+    fn audit_flushes_each_event() {
+        use std::io::BufWriter;
+        use std::sync::{Arc, Mutex};
+
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let file = std::fs::OpenOptions::new()
+            .write(true)
+            .open(tmp.path())
+            .unwrap();
+        let log: AuditLog = Some(Arc::new(Mutex::new(BufWriter::new(file))));
+
+        audit(&log, "connect", &[("host", "example.com")]);
+
+        // The writer is still alive (never dropped or flushed here), so the
+        // event reaches disk only if audit() flushes after each write.
+        let contents = std::fs::read_to_string(tmp.path()).unwrap();
+        assert!(
+            contents.contains(r#""event":"connect""#) && contents.contains("example.com"),
+            "audit event must be flushed to disk immediately, got: {contents:?}"
+        );
+    }
 
     // --- HostMap ---
 


### PR DESCRIPTION
`redan logs` was dumping the raw `redan.log` stderr capture. This makes it the real-time view of a session's **audit stream** instead, rendered as logfmt.

**What it does now.** `redan logs <id>` reads the per-session `audit.jsonl` and prints logfmt (`key=value`, Heroku style):

```
ts=2026-06-20T12:30:01Z severity=info event=connect host=api.anthropic.com
ts=2026-06-20T12:30:04Z severity=warning event=reject host=evil.com reason=not_allowed
```

`-f` follows live as events are appended; `--json` passes the raw JSON events through for `jq`. Greppable by design: `redan logs <id> | grep event=reject`. (The raw `redan.log` is still on disk at the session path if you need redan's own debug output.)

**Three commits, following the OWASP Logging Cheat Sheet:**
1. **flush** per audit event, so the log is tailable in real time and durable if the VM dies mid-session.
2. **severity** on every event (`info` / `warning`), an OWASP "what" attribute.
3. the **logfmt viewer**. The renderer treats event values as untrusted (the guest agent picks the hostnames it connects to), so it quotes and escapes them: control characters and ANSI escapes become a visible `\xNN`, and a line that won't parse becomes a safe `raw=` field. A crafted hostname can't forge a log line or drive your terminal.

**Scoped out into a follow-up "audit hardening" PR:** the remaining two OWASP items, sanitizing values at *write* time (so the raw `--json`/`cat` path is safe against the rare DEL/C1 control chars serde doesn't escape) and restricting the world-readable state-dir perms (`0755`/`0644` today). Separable, and they touch different files.

**One UX question:** the default view shows every event, including `dns` lookups, which are numerous and a bit noisy on a real session. I kept it complete and greppable (`grep -v event=dns`), which is the logfmt way, but I can omit `dns` by default with a flag to include if you'd rather.

217 tests green; the sanitization is covered (newline + ANSI in a hostname stays one line, no raw control chars; corrupt line becomes `raw=`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `redan logs` now supports `--follow` for live log streaming.
  * `redan logs` now supports `--json` to emit raw JSON events.
* **Improvements**
  * Audit events now include a `severity` field (e.g., `reject` → `warning`).
  * Log output is rendered into terminal-safe logfmt for readability and safety.
* **Bug Fixes**
  * Improved handling when output is piped (e.g., broken pipes now exit cleanly).
  * Logs are written/flushed promptly so new events appear immediately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->